### PR TITLE
Guzzl

### DIFF
--- a/src/fights.ts
+++ b/src/fights.ts
@@ -62,7 +62,7 @@ import {
 import { fillAsdonMartinTo } from "./asdon";
 import { Macro, withMacro } from "./combat";
 import { freeFightFamiliar, meatFamiliar } from "./familiar";
-import { clamp, ensureEffect, mapMonster, questStep, setChoice } from "./lib";
+import { clamp, ensureEffect, mapMonster, prepWandererZone, questStep, setChoice } from "./lib";
 import { freeFightMood, meatMood } from "./mood";
 import { freeFightOutfit, meatOutfit, Requirement } from "./outfit";
 import { withStash } from "./stash";
@@ -470,7 +470,7 @@ const freeFightSources = [
 
   new FreeFight(
     () => get("_sausageFights") === 0 && have($item`Kramco Sausage-o-Matic™`),
-    () => adv1($location`Noob Cave`, -1, ""),
+    () => adv1(prepWandererZone(), -1, ""),
     {
       requirements: () => [
         new Requirement([], {

--- a/src/index.ts
+++ b/src/index.ts
@@ -359,7 +359,7 @@ function barfTurn() {
     useFamiliar(freeFightFamiliar());
     freeFightOutfit([new Requirement([], { forceEquip: $items`I Voted!" sticker` })]);
     adventureMacroAuto(
-      $location`noob cave`,
+      prepWandererZone(),
       Macro.if_(
         `monsterid ${$monster`Angry ghost`.id}`,
         Macro.skill("saucestorm").repeat()

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ import { Macro, withMacro } from "./combat";
 import { runDiet } from "./diet";
 import { freeFightFamiliar, meatFamiliar } from "./familiar";
 import { dailyFights, freeFights, safeRestore } from "./fights";
-import { ensureEffect, questStep, setChoice, voterSetup } from "./lib";
+import { ensureEffect, questStep, setChoice, voterSetup, prepWandererZone } from "./lib";
 import { meatMood } from "./mood";
 import { freeFightOutfit, meatOutfit, Requirement } from "./outfit";
 import { withStash } from "./stash";
@@ -302,7 +302,7 @@ function barfTurn() {
   useFamiliar(meatFamiliar());
 
   const embezzlerUp = getCounters("Digitize Monster", 0, 0).trim() !== "";
-  let location = embezzlerUp ? $location`Noob Cave` : $location`Barf Mountain`;
+  let location = embezzlerUp ? prepWandererZone() : $location`Barf Mountain`;
   if (
     !get("_envyfishEggUsed") &&
     (booleanModifier("Adventure Underwater") ||

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,5 +1,18 @@
-import { cliExecute, haveSkill, mallPrice, runChoice, toUrl, useSkill, visitUrl } from "kolmafia";
-import { $item, $skill, get, have, property, set } from "libram";
+import { canAdv } from "canadv.ash";
+import {
+  buy,
+  cliExecute,
+  haveSkill,
+  mallPrice,
+  print,
+  runChoice,
+  toItem,
+  toUrl,
+  use,
+  useSkill,
+  visitUrl,
+} from "kolmafia";
+import { $effect, $item, $items, $location, $skill, get, have, property, set } from "libram";
 
 export function setChoice(adventure: number, value: number) {
   set(`choiceAdventure${adventure}`, `${value}`);
@@ -102,4 +115,170 @@ export function voterSetup() {
   visitUrl(
     `choice.php?option=1&whichchoice=1331&g=${monsterVote}&local[]=${firstInit}&local[]=${secondInit}`
   );
+}
+interface zonePotion {
+  zone: String;
+  effect: Effect;
+  potion: Item;
+}
+
+const zonePotions = [
+  {
+    zone: "Spaaace",
+    effect: $effect`Transpondent`,
+    potion: $item`transporter transponder`,
+  },
+  {
+    zone: "Wormwood",
+    effect: $effect`absinthe-minded`,
+    potion: $item`tiny bottle of absinthe`,
+  },
+];
+
+export function prepWandererZone() {
+  const defaultLocation =
+    get("_spookyAirportToday") || get("spookyAirportAlways")
+      ? $location`the deep dark jungle`
+      : $location`noob cave`;
+  if (!have($item`guzzlr tablet`)) return defaultLocation;
+  if (get("questGuzzlr") === "unstarted") {
+    if (
+      get("_guzzlrPlatinumDeliveries") === 0 &&
+      get("guzzlrGoldDeliveries") >= 5 &&
+      (get("guzzlrPlatinumDeliveries") < 30 ||
+        (get("guzzlrGoldDeliveries") >= 150 && get("guzzlrBronzeDeliveries") >= 196))
+    ) {
+      set("choiceAdventure1412", 4);
+      use(1, $item`guzzlr tablet`);
+    } else if (
+      get("_guzzlrGoldDeliveries") < 3 &&
+      get("guzzlrBronzeDeliveries") >= 5 &&
+      (get("guzzlrGoldDeliveries") < 150 || get("guzzlrBronzeDeliveries") >= 196)
+    ) {
+      set("choiceAdventure1412", 3);
+      use(1, $item`guzzlr tablet`);
+    } else {
+      set("choiceAdventure1412", 2);
+      use(1, $item`guzzlr tablet`);
+    }
+  }
+
+  if (get("questGuzzlr") !== "unstarted") {
+    if (!guzzlrCheck() && !get("_guzzlrQuestAbandoned")) {
+      dropGuzzlrQuest();
+    }
+  }
+
+  if (get("questGuzzlr") === "unstarted") {
+    if (
+      get("_guzzlrPlatinumDeliveries") === 0 &&
+      get("guzzlrGoldDeliveries") >= 5 &&
+      (get("guzzlrPlatinumDeliveries") < 30 ||
+        (get("guzzlrGoldDeliveries") >= 150 && get("guzzlrBronzeDeliveries") >= 196))
+    ) {
+      set("choiceAdventure1412", 4);
+      use(1, $item`guzzlr tablet`);
+    } else if (
+      get("_guzzlrGoldDeliveries") < 3 &&
+      get("guzzlrBronzeDeliveries") >= 5 &&
+      (get("guzzlrGoldDeliveries") < 150 || get("guzzlrBronzeDeliveries") >= 196)
+    ) {
+      set("choiceAdventure1412", 3);
+      use(1, $item`guzzlr tablet`);
+    } else {
+      set("choiceAdventure1412", 2);
+      use(1, $item`guzzlr tablet`);
+    }
+  }
+
+  let freeFightZone = defaultLocation;
+  if (guzzlrCheck()) {
+    freeFightZone = get("guzzlrQuestLocation") || defaultLocation;
+    if (get("guzzlrQuestTier") === "platinum") {
+      zonePotions.forEach((place) => {
+        if (freeFightZone.zone === place.zone && !have(place.effect)) {
+          if (!have(place.potion)) {
+            buy(1, place.potion, 10000);
+          }
+          use(1, place.potion);
+        }
+      });
+    }
+  }
+  if (freeFightZone === get("guzzlrQuestLocation")) {
+    if (property.getString("guzzlrQuestBooze") === "Guzzlr cocktail set") {
+      if (
+        !$items`buttery boy, steamboat, ghiaccio colada, nog-on-the-cob, sourfinger`.some((drink) =>
+          have(drink)
+        )
+      ) {
+        cliExecute("make buttery boy");
+      }
+    } else {
+      const guzzlrBooze = toItem(get("guzzlrQuestBooze"));
+      if (guzzlrBooze === $item`none`) {
+        freeFightZone = defaultLocation;
+      } else if (!have(guzzlrBooze)) {
+        print(`just picking up some booze before we roll`, "blue");
+        cliExecute("acquire " + get("guzzlrQuestBooze"));
+      }
+    }
+  }
+  return freeFightZone;
+}
+
+function guzzlrCheck() {
+  const guzzlZone = get("guzzlrQuestLocation");
+  if (!guzzlZone) return false;
+  const forbiddenZones: String[] = ["The Rabbit Hole"]; //can't stockpile these potions,
+  if (!get("_spookyAirportToday") && !get("spookyAirportAlways")) {
+    forbiddenZones.push("Conspiracy Island");
+  }
+  if (!get("_stenchAirportToday") && !get("stenchAirportAlways")) {
+    forbiddenZones.push("Dinseylandfill");
+  }
+  if (!get("_hotAirportToday") && !get("hotAirportAlways")) {
+    forbiddenZones.push("That 70s Volcano");
+  }
+  if (!get("_coldAirportToday") && !get("coldAirportAlways")) {
+    forbiddenZones.push("The Glaciest");
+  }
+  if (!get("_sleazeAirportToday") && !get("sleazeAirportAlways")) {
+    forbiddenZones.push("Spring Break Beach");
+  }
+
+  zonePotions.forEach((place) => {
+    if (guzzlZone.zone === place.zone && have(place.effect)) {
+      if (!have(place.potion)) {
+        buy(1, place.potion, 10000);
+      }
+      use(1, place.potion);
+    }
+  });
+  if (
+    forbiddenZones.includes(guzzlZone.zone) ||
+    !guzzlZone.wanderers ||
+    guzzlZone === $location`The Oasis` ||
+    guzzlZone === $location`The Bubblin' Caldera` ||
+    guzzlZone.environment === "underwater" ||
+    guzzlZone === $location`Barrrney's Barrr` ||
+    guzzlZone === $location`The F'c'le` ||
+    guzzlZone === $location`the poop deck` ||
+    guzzlZone === $location`belowdecks` ||
+    guzzlZone === $location`the 8-bit realm` ||
+    (guzzlZone.zone === "BatHole" && guzzlZone !== $location`The Bat Hole Entrance`) ||
+    !canAdv(guzzlZone, false)
+  ) {
+    return false;
+  } else {
+    return true;
+  }
+}
+
+function dropGuzzlrQuest() {
+  print("We hate this guzzlr quest!", "blue");
+  set("choiceAdventure1412", "");
+  visitUrl("inventory.php?tap=guzzlr", false);
+  runChoice(1);
+  runChoice(5);
 }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -267,6 +267,7 @@ function guzzlrCheck() {
     guzzlZone === $location`belowdecks` ||
     guzzlZone === $location`8-Bit Realm` ||
     (guzzlZone.zone === "BatHole" && guzzlZone !== $location`The Bat Hole Entrance`) ||
+    guzzlZone === $location`The Secret Government Laboratory` ||
     !canAdv(guzzlZone, false)
   ) {
     return false;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -265,7 +265,7 @@ function guzzlrCheck() {
     guzzlZone === $location`The F'c'le` ||
     guzzlZone === $location`the poop deck` ||
     guzzlZone === $location`belowdecks` ||
-    guzzlZone === $location`the 8-bit realm` ||
+    guzzlZone === $location`8-Bit Realm` ||
     (guzzlZone.zone === "BatHole" && guzzlZone !== $location`The Bat Hole Entrance`) ||
     !canAdv(guzzlZone, false)
   ) {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -191,12 +191,13 @@ export function prepWandererZone() {
     }
   }
 
-  let freeFightZone = defaultLocation;
-  if (guzzlrCheck()) {
-    freeFightZone = get("guzzlrQuestLocation") || defaultLocation;
+  const guzzlZone = get("guzzlrQuestLocation");
+  if (!guzzlrCheck()) return defaultLocation;
+  else if (!guzzlZone) return defaultLocation;
+  else {
     if (get("guzzlrQuestTier") === "platinum") {
       zonePotions.forEach((place) => {
-        if (freeFightZone.zone === place.zone && !have(place.effect)) {
+        if (guzzlZone.zone === place.zone && !have(place.effect)) {
           if (!have(place.potion)) {
             buy(1, place.potion, 10000);
           }
@@ -204,8 +205,6 @@ export function prepWandererZone() {
         }
       });
     }
-  }
-  if (freeFightZone === get("guzzlrQuestLocation")) {
     if (property.getString("guzzlrQuestBooze") === "Guzzlr cocktail set") {
       if (
         !$items`buttery boy, steamboat, ghiaccio colada, nog-on-the-cob, sourfinger`.some((drink) =>
@@ -217,14 +216,14 @@ export function prepWandererZone() {
     } else {
       const guzzlrBooze = toItem(get("guzzlrQuestBooze"));
       if (guzzlrBooze === $item`none`) {
-        freeFightZone = defaultLocation;
+        return defaultLocation;
       } else if (!have(guzzlrBooze)) {
         print(`just picking up some booze before we roll`, "blue");
         cliExecute("acquire " + get("guzzlrQuestBooze"));
       }
     }
+    return guzzlZone;
   }
-  return freeFightZone;
 }
 
 function guzzlrCheck() {

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -1,0 +1,3 @@
+declare module "canadv.ash" {
+  export function canAdv(location: Location, x: boolean): boolean;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,6 +36,7 @@ module.exports = {
   },
   plugins: [],
   externals: {
+    "canadv.ash": "commonjs canadv.ash",
     kolmafia: "commonjs kolmafia",
   },
 };


### PR DESCRIPTION
Prioritizes first getting to 30/150/196, then by the order platinum>gold>bronze. Rejects any zone that fails canAdv (by the way, you now need canAdv), any zone that requires pirate apparel, any zone with screambats, the oasis, any zone down the rabbit hole, the bubblin' caldera, and any zone from a charter you don't currently have access to. Specifically makes buttery boys for platinum quests, but will use any existing platinum drinks.