### PR TITLE
start market square quests to open ghost zones

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -426,6 +426,19 @@ export function main(argString = "") {
     cliExecute("ccs garbo");
     safeRestore();
 
+    if (questStep("questM23Meatsmith") === -1) {
+      visitUrl("shop.php?whichshop=meatsmith&action=talk");
+      runChoice(1);
+    }
+    if (questStep("questM24Doc") === -1) {
+      visitUrl("shop.php?whichshop=doc&action=talk");
+      runChoice(1);
+    }
+    if (questStep("questM25Armorer") === -1) {
+      visitUrl("shop.php?whichshop=armory&action=talk");
+            runChoice(1);
+    }
+
     // FIXME: Dynamically figure out pointer ring approach.
     withStash($items`haiku katana, repaid diaper`, () => {
       // 0. diet stuff.

--- a/src/index.ts
+++ b/src/index.ts
@@ -436,7 +436,7 @@ export function main(argString = "") {
     }
     if (questStep("questM25Armorer") === -1) {
       visitUrl("shop.php?whichshop=armory&action=talk");
-            runChoice(1);
+      runChoice(1);
     }
 
     // FIXME: Dynamically figure out pointer ring approach.


### PR DESCRIPTION
As of now, script will enter an infinite loop if you have a ghost quest in a presently-locked zone. The only places where that can happen are the madness bakery, the overgrown lot, and the skeleton store. 