### PR TITLE
Improve resilience against time-spinner pranks

### DIFF
--- a/src/fights.ts
+++ b/src/fights.ts
@@ -238,6 +238,7 @@ const pygmyMacro = Macro.if_(
     Macro.trySkill("Feel Hatred").item($item`divine champagne popper`)
   )
   .if_("monstername pygmy janitor", Macro.item($item`tennis ball`))
+  .if_("monstername time-spinner prank", Macro.meatKill())
   .abort();
 
 const freeFightSources = [


### PR DESCRIPTION
Presently, we abort if we encounter a time-spinner prank during our pygmy fights. This PR adds more resilience by expressly meatkilling any time-spun pranksters we encounter during pygmy times.