### PR TITLE
Overhaul embezzler logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "core-js": "^3.8.0",
     "kolmafia": "^1.0.11",
-    "libram": "^0.0.8",
+    "libram": "^0.0.9",
     "yarn": "^1.22.10"
   },
   "devDependencies": {

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -253,7 +253,12 @@ const embezzlerSources = [
         ).step(embezzlerMacro())
       );
     },
-    [new Requirement([], { forceEquip: $items`backup camera` })],
+    [
+      new Requirement([], {
+        forceEquip: $items`backup camera`,
+        bonusEquip: new Map([[$item`backup camera`, 5000]]),
+      }),
+    ],
     true
   ),
   new EmbezzlerFight(

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -18,6 +18,7 @@ import {
   myAdventures,
   myAscensions,
   myClass,
+  myHash,
   myHp,
   myMaxhp,
   myMaxmp,
@@ -306,7 +307,14 @@ function getEmbezzlerFight(): EmbezzlerFight | null {
       () => 0,
       () => {
         retrieveItem($item`pocket wish`);
-        cliExecute("genie fight knob goblin embezzler");
+        visitUrl("inv_use.php?pwd=" + myHash() + "&which=3&whichitem=9537", false, true);
+        visitUrl(
+          "choice.php?pwd&whichchoice=1267&option=1&wish=to fight a Knob Goblin Embezzler ",
+          true,
+          true
+        );
+        visitUrl("main.php", false);
+        runCombat();
       }
     );
   }

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -319,6 +319,7 @@ export function dailyFights() {
       set("_garbo_weightChain", true);
     }
 
+    // REMAINING EMBEZZLER FIGHTS
     let nextFight = getEmbezzlerFight();
     while (nextFight !== null) {
       withMacro(embezzlerMacro(), () => {
@@ -343,9 +344,10 @@ export function dailyFights() {
             retrieveItem($item`pulled green taffy`);
             if (!have($effect`Fishy`)) use($item`fishy pipe`);
             nextFight.run($location`The Briny Deeps`);
+          } else {
+            meatOutfit(true);
+            nextFight.run(prepWandererZone());
           }
-          meatOutfit(true);
-          nextFight.run(prepWandererZone());
         }
       });
       nextFight = getEmbezzlerFight();

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -348,6 +348,8 @@ export function dailyFights() {
     // REMAINING EMBEZZLER FIGHTS
     let nextFight = getEmbezzlerFight();
     while (nextFight !== null) {
+      if (have($skill`musk of the moose`) && !have($effect`musk of the moose`))
+        useSkill($skill`musk of the moose`);
       withMacro(embezzlerMacro(), () => {
         if (nextFight) {
           useFamiliar(meatFamiliar());

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -94,17 +94,20 @@ class EmbezzlerFight {
   available: () => boolean;
   potential: () => number;
   run: (location: Location) => void;
+  requirements: Requirement[];
   draggable: boolean;
 
   constructor(
     available: () => boolean,
     potential: () => number,
     run: (location: Location) => void,
+    requirements: Requirement[] = [],
     draggable = false
   ) {
     this.available = available;
     this.potential = potential;
     this.run = run;
+    this.requirements = requirements;
     this.draggable = draggable;
   }
 }
@@ -248,6 +251,7 @@ const embezzlerSources = [
         ).step(embezzlerMacro())
       );
     },
+    [new Requirement([], { forceEquip: $items`backup camera` })],
     true
   ),
   new EmbezzlerFight(
@@ -365,7 +369,7 @@ export function dailyFights() {
             (have($effect`Fishy`) || (have($item`fishy pipe`) && !get("_fishyPipeUsed"))) &&
             !have($item`envyfish egg`)
           ) {
-            meatOutfit(true, [], true);
+            meatOutfit(true, nextFight.requirements, true);
             if (get("questS01OldGuy") === "unstarted") {
               visitUrl("place.php?whichplace=sea_oldman&action=oldman_oldman");
             }
@@ -373,7 +377,7 @@ export function dailyFights() {
             if (!have($effect`Fishy`)) use($item`fishy pipe`);
             nextFight.run($location`The Briny Deeps`);
           } else {
-            meatOutfit(true);
+            meatOutfit(true, nextFight.requirements);
             nextFight.run(prepWandererZone());
           }
         }

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -314,77 +314,81 @@ function getEmbezzlerFight(): EmbezzlerFight | null {
 }
 
 export function dailyFights() {
-  withStash($items`Spooky putty sheet`, () => {
-    embezzlerSetup();
+  if (embezzlerSources.some((source) => source.potential)) {
+    withStash($items`Spooky putty sheet`, () => {
+      embezzlerSetup();
 
-    // FIRST EMBEZZLER CHAIN
-    if (have($familiar`Pocket Professor`) && !get<boolean>("_garbo_meatChain", false)) {
-      const fightSource = getEmbezzlerFight();
-      if (!fightSource) return;
-      useFamiliar($familiar`Pocket Professor`);
-      meatOutfit(true, [new Requirement([], { forceEquip: $items`Pocket Professor memory chip` })]);
-      withMacro(firstChainMacro(), () => fightSource.run($location`Noob Cave`));
-      set("_garbo_meatChain", true);
-    }
+      // FIRST EMBEZZLER CHAIN
+      if (have($familiar`Pocket Professor`) && !get<boolean>("_garbo_meatChain", false)) {
+        const fightSource = getEmbezzlerFight();
+        if (!fightSource) return;
+        useFamiliar($familiar`Pocket Professor`);
+        meatOutfit(true, [
+          new Requirement([], { forceEquip: $items`Pocket Professor memory chip` }),
+        ]);
+        withMacro(firstChainMacro(), () => fightSource.run($location`Noob Cave`));
+        set("_garbo_meatChain", true);
+      }
 
-    // START DIGITIZE IF APPLICABLE
-    if (
-      getCounters("Digitize Monster", 0, 100).trim() === "" &&
-      get("_mushroomGardenFights") === 0
-    ) {
-      if (have($item`packet of mushroom spores`)) use($item`packet of mushroom spores`);
-      // adventure in mushroom garden to start digitize timer.
-      freeFightOutfit();
-      useFamiliar(meatFamiliar());
-      adventureMacro($location`Your Mushroom Garden`, Macro.meatKill());
-    }
+      // START DIGITIZE IF APPLICABLE
+      if (
+        getCounters("Digitize Monster", 0, 100).trim() === "" &&
+        get("_mushroomGardenFights") === 0
+      ) {
+        if (have($item`packet of mushroom spores`)) use($item`packet of mushroom spores`);
+        // adventure in mushroom garden to start digitize timer.
+        freeFightOutfit();
+        useFamiliar(meatFamiliar());
+        adventureMacro($location`Your Mushroom Garden`, Macro.meatKill());
+      }
 
-    // SECOND EMBEZZLER CHAIN
-    if (have($familiar`Pocket Professor`) && !get<boolean>("_garbo_weightChain", false)) {
-      const fightSource = getEmbezzlerFight();
-      if (!fightSource) return;
-      useFamiliar($familiar`Pocket Professor`);
-      maximizeCached(["Familiar Weight"], { forceEquip: $items`Pocket Professor memory chip` });
-      withMacro(secondChainMacro(), () => fightSource.run($location`Noob Cave`));
-      set("_garbo_weightChain", true);
-    }
+      // SECOND EMBEZZLER CHAIN
+      if (have($familiar`Pocket Professor`) && !get<boolean>("_garbo_weightChain", false)) {
+        const fightSource = getEmbezzlerFight();
+        if (!fightSource) return;
+        useFamiliar($familiar`Pocket Professor`);
+        maximizeCached(["Familiar Weight"], { forceEquip: $items`Pocket Professor memory chip` });
+        withMacro(secondChainMacro(), () => fightSource.run($location`Noob Cave`));
+        set("_garbo_weightChain", true);
+      }
 
-    // REMAINING EMBEZZLER FIGHTS
-    let nextFight = getEmbezzlerFight();
-    while (nextFight !== null) {
-      if (have($skill`musk of the moose`) && !have($effect`musk of the moose`))
-        useSkill($skill`musk of the moose`);
-      withMacro(embezzlerMacro(), () => {
-        if (nextFight) {
-          useFamiliar(meatFamiliar());
-          if (
-            nextFight.draggable &&
-            !get("_envyfishEggUsed") &&
-            (booleanModifier("Adventure Underwater") ||
-              $items`aerated diving helmet, crappy mer-kin mask, Mer-kin gladiator mask, Mer-kin scholar mask, old SCUBA tank, The Crown of Ed the Undying`.some(
-                have
-              )) &&
-            (booleanModifier("Underwater Familiar") ||
-              $items`little bitty bathysphere, das boot`.some(have)) &&
-            (have($effect`Fishy`) || (have($item`fishy pipe`) && !get("_fishyPipeUsed"))) &&
-            !have($item`envyfish egg`)
-          ) {
-            meatOutfit(true, nextFight.requirements, true);
-            if (get("questS01OldGuy") === "unstarted") {
-              visitUrl("place.php?whichplace=sea_oldman&action=oldman_oldman");
+      // REMAINING EMBEZZLER FIGHTS
+      let nextFight = getEmbezzlerFight();
+      while (nextFight !== null) {
+        if (have($skill`musk of the moose`) && !have($effect`musk of the moose`))
+          useSkill($skill`musk of the moose`);
+        withMacro(embezzlerMacro(), () => {
+          if (nextFight) {
+            useFamiliar(meatFamiliar());
+            if (
+              nextFight.draggable &&
+              !get("_envyfishEggUsed") &&
+              (booleanModifier("Adventure Underwater") ||
+                $items`aerated diving helmet, crappy mer-kin mask, Mer-kin gladiator mask, Mer-kin scholar mask, old SCUBA tank, The Crown of Ed the Undying`.some(
+                  have
+                )) &&
+              (booleanModifier("Underwater Familiar") ||
+                $items`little bitty bathysphere, das boot`.some(have)) &&
+              (have($effect`Fishy`) || (have($item`fishy pipe`) && !get("_fishyPipeUsed"))) &&
+              !have($item`envyfish egg`)
+            ) {
+              meatOutfit(true, nextFight.requirements, true);
+              if (get("questS01OldGuy") === "unstarted") {
+                visitUrl("place.php?whichplace=sea_oldman&action=oldman_oldman");
+              }
+              retrieveItem($item`pulled green taffy`);
+              if (!have($effect`Fishy`)) use($item`fishy pipe`);
+              nextFight.run($location`The Briny Deeps`);
+            } else {
+              meatOutfit(true, nextFight.requirements);
+              nextFight.run(prepWandererZone());
             }
-            retrieveItem($item`pulled green taffy`);
-            if (!have($effect`Fishy`)) use($item`fishy pipe`);
-            nextFight.run($location`The Briny Deeps`);
-          } else {
-            meatOutfit(true, nextFight.requirements);
-            nextFight.run(prepWandererZone());
           }
-        }
-      });
-      nextFight = getEmbezzlerFight();
-    }
-  });
+        });
+        nextFight = getEmbezzlerFight();
+      }
+    });
+  }
 }
 
 type FreeFightOptions = {

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -13,6 +13,7 @@ import {
   getClanLounge,
   getCounters,
   handlingChoice,
+  inMultiFight,
   itemAmount,
   mallPrice,
   myAdventures,
@@ -315,6 +316,7 @@ function getEmbezzlerFight(): EmbezzlerFight | null {
         );
         visitUrl("main.php", false);
         runCombat();
+        while (inMultiFight()) runCombat();
       }
     );
   }
@@ -332,9 +334,10 @@ export function dailyFights() {
         if (!fightSource) return;
         useFamiliar($familiar`Pocket Professor`);
         meatOutfit(true, [
+          ...fightSource.requirements,
           new Requirement([], { forceEquip: $items`Pocket Professor memory chip` }),
         ]);
-        withMacro(firstChainMacro(), () => fightSource.run($location`Noob Cave`));
+        withMacro(firstChainMacro(), () => fightSource.run(prepWandererZone()));
         set("_garbo_meatChain", true);
       }
 
@@ -355,8 +358,14 @@ export function dailyFights() {
         const fightSource = getEmbezzlerFight();
         if (!fightSource) return;
         useFamiliar($familiar`Pocket Professor`);
-        maximizeCached(["Familiar Weight"], { forceEquip: $items`Pocket Professor memory chip` });
-        withMacro(secondChainMacro(), () => fightSource.run($location`Noob Cave`));
+        let requirements = new Requirement(["Familiar Weight"], {
+          forceEquip: $items`Pocket Professor memory chip`,
+        });
+        for (let requirement of fightSource.requirements) {
+          requirements = requirements.merge(requirement);
+        }
+        maximizeCached(requirements.maximizeParameters(), requirements.maximizeOptions());
+        withMacro(secondChainMacro(), () => fightSource.run(prepWandererZone()));
         set("_garbo_weightChain", true);
       }
 

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -358,12 +358,12 @@ export function dailyFights() {
         const fightSource = getEmbezzlerFight();
         if (!fightSource) return;
         useFamiliar($familiar`Pocket Professor`);
-        let requirements = new Requirement(["Familiar Weight"], {
-          forceEquip: $items`Pocket Professor memory chip`,
-        });
-        for (let requirement of fightSource.requirements) {
-          requirements = requirements.merge(requirement);
-        }
+        const requirements = Requirement.merge([
+          new Requirement(["Familiar Weight"], {
+            forceEquip: $items`Pocket Professor memory chip`,
+          }),
+          ...fightSource.requirements,
+        ]);
         maximizeCached(requirements.maximizeParameters(), requirements.maximizeOptions());
         withMacro(secondChainMacro(), () => fightSource.run(prepWandererZone()));
         set("_garbo_weightChain", true);

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -1,12 +1,14 @@
+import { canAdv } from "canadv.ash";
 import {
   abort,
   adv1,
   availableAmount,
+  booleanModifier,
   chatPrivate,
   cliExecute,
+  combatRateModifier,
   eat,
   equip,
-  faxbot,
   getCampground,
   getClanLounge,
   getCounters,
@@ -34,6 +36,7 @@ import {
   toInt,
   use,
   useFamiliar,
+  userConfirm,
   useSkill,
   visitUrl,
   wait,
@@ -87,112 +90,267 @@ function faxEmbezzler(): void {
   }
 }
 
-export function dailyFights() {
+class EmbezzlerFight {
+  available: () => boolean;
+  potential: () => number;
+  run: (location: Location) => void;
+  draggable: boolean;
+
+  constructor(
+    available: () => boolean,
+    potential: () => number,
+    run: (location: Location) => void,
+    draggable = false
+  ) {
+    this.available = available;
+    this.potential = potential;
+    this.run = run;
+    this.draggable = draggable;
+  }
+}
+
+const firstChainMacro = () =>
+  Macro.if_(
+    "monstername Knob Goblin Embezzler",
+    Macro.if_(
+      "!hasskill Lecture on Relativity",
+      Macro.trySkill("Digitize")
+        .externalIf(get("spookyPuttyCopiesMade") < 5, Macro.tryItem($item`Spooky Putty sheet`))
+        .externalIf(
+          !get("_cameraUsed") && !have($item`shaking 4-d camera`),
+          Macro.tryItem($item`4-d camera`)
+        )
+    )
+      .trySkill("Lecture on Relativity")
+      .meatKill()
+  ).abort();
+
+const secondChainMacro = () =>
+  Macro.if_(
+    "monstername Knob Goblin Embezzler",
+    Macro.if_("!hasskill Lecture on Relativity", Macro.trySkill("Meteor Shower"))
+      .trySkill("Lecture on Relativity")
+      .meatKill()
+  ).abort();
+
+const embezzlerMacro = () =>
+  Macro.if_(
+    "monstername Knob Goblin Embezzler",
+    Macro.if_("snarfblat 186", Macro.item($item`green taffy`))
+      .externalIf(
+        get("_sourceTerminalDigitizeMonster") !== $monster`Knob Goblin Embezzler`,
+        Macro.trySkill("Digitize")
+      )
+      .externalIf(get("spookyPuttyCopiesMade") < 5, Macro.tryItem($item`Spooky Putty sheet`))
+      .externalIf(
+        !get("_cameraUsed") && !have($item`shaking 4-d camera`),
+        Macro.tryItem($item`4-d camera`)
+      )
+      .meatKill()
+  ).abort();
+
+const embezzlerSources = [
+  new EmbezzlerFight(
+    () =>
+      get("_sourceTerminalDigitizeMonster") === $monster`Knob Goblin Embezzler` &&
+      getCounters("Digitize Monster", 0, 0).trim() !== "",
+    () => (SourceTerminal.have() && get("_sourceTerminalDigitizeUses") === 0 ? 1 : 0),
+    (location: Location) => {
+      adv1(location);
+    }
+  ),
+  new EmbezzlerFight(
+    () => have($item`Clan VIP Lounge key`) && !get("_photocopyUsed"),
+    () => (have($item`Clan VIP Lounge key`) && !get("_photocopyUsed") ? 1 : 0),
+    () => {
+      faxEmbezzler();
+      use($item`photocopied monster`);
+    }
+  ),
+  new EmbezzlerFight(
+    () => canAdv($location`Knob Treasury`, true) && !get("_freePillKeeperUsed"),
+    () => (canAdv($location`Knob Treasury`, true) && !get("_freePillKeeperUsed") ? 1 : 0),
+    () => {
+      cliExecute("pillkeeper semirare");
+      adv1($location`Knob Treasury`);
+    }
+  ),
+  new EmbezzlerFight(
+    () =>
+      ChateauMantegna.have() &&
+      !ChateauMantegna.paintingFought() &&
+      ChateauMantegna.paintingMonster() === $monster`Knob Goblin Embezzler`,
+    () =>
+      ChateauMantegna.have() &&
+      !ChateauMantegna.paintingFought() &&
+      ChateauMantegna.paintingMonster() === $monster`Knob Goblin Embezzler`
+        ? 1
+        : 0,
+    () => ChateauMantegna.fightPainting()
+  ),
+  new EmbezzlerFight(
+    () =>
+      have($item`Spooky putty monster`) &&
+      get("spookyPuttyMonster") === $monster`Knob Goblin Embezzler`,
+    () => {
+      if (have($item`Spooky putty sheet`)) {
+        return 5 - get("spookyPuttyCopiesMade");
+      }
+      if (
+        have($item`Spooky putty monster`) &&
+        get("spookyPuttyMonster") === $monster`Knob Goblin Embezzler`
+      ) {
+        return 6 - get("spookyPuttyCopiesMade");
+      }
+      return 0;
+    },
+    () => use($item`Spooky putty monster`)
+  ),
+  new EmbezzlerFight(
+    () =>
+      get("lastCopyableMonster") === $monster`Knob Goblin Embezzler` &&
+      have($item`backup camera`) &&
+      get<number>("_backUpUses") < 11,
+    () => (have($item`backup camera`) ? 11 - get<number>("_backUpUses") : 0),
+    (location: Location) => {
+      const realLocation = location.combatPercent >= 100 ? location : $location`Noob Cave`;
+      adventureMacro(
+        realLocation,
+        Macro.if_(
+          "!monstername Knob Goblin Embezzler",
+          Macro.skill("Back-Up to Your Last Enemy")
+        ).step(embezzlerMacro())
+      );
+    },
+    true
+  ),
+  new EmbezzlerFight(
+    () => false,
+    () => (have($familiar`Pocket Professor`) && !get<boolean>("_garbo_meatChain", false) ? 1 : 0),
+    () => {}
+  ),
+  new EmbezzlerFight(
+    () => false,
+    () => (have($familiar`Pocket Professor`) && !get<boolean>("_garbo_weightChain", false) ? 1 : 0),
+    () => {}
+  ),
+];
+
+function embezzlerSetup() {
   meatMood(true).execute(myAdventures() * 1.04 + 50);
   safeRestore();
-  if (have($item`Clan VIP Lounge key`)) {
-    const embezzler = $monster`Knob Goblin embezzler`;
-    if (
-      (!have($item`photocopied monster`) || get("photocopyMonster") !== embezzler) &&
-      !get("_photocopyUsed")
-    ) {
-      faxEmbezzler();
-    }
-
-    if (getClanLounge()["Clan pool table"] !== undefined) {
-      while (get("_poolGames") < 3) cliExecute("pool aggressive");
-    }
-    if (!get<boolean>("_garbo_professorLecturesUsed", false) || get("spookyPuttyCopiesMade") < 5) {
-      withStash($items`Spooky Putty sheet`, () => {
-        if (
-          have($familiar`Pocket Professor`) &&
-          !get<boolean>("_garbo_professorLecturesUsed", false)
-        ) {
-          ensureEffect($effect`Peppermint Twisted`);
-          if (mySpleenUse() < spleenLimit()) ensureEffect($effect`Eau d' Clochard`);
-          if (mySpleenUse() < spleenLimit() && have($item`body spradium`)) {
-            ensureEffect($effect`Boxing Day Glow`);
-          }
-
-          // First round of prof copies with meat drop gear on.
-          if (!get("_photocopyUsed")) {
-            freeFightMood().execute(30);
-            withStash($items`Platinum Yendorian Express Card`, () => {
-              if (have($item`Platinum Yendorian Express Card`)) {
-                use($item`Platinum Yendorian Express Card`);
-              }
-            });
-            if (have($item`license to chill`) && !get("_licenseToChillUsed"))
-              use($item`license to chill`);
-
-            if (SourceTerminal.have()) SourceTerminal.educate([$skill`Extract`, $skill`Digitize`]);
-
-            if (!get("_cameraUsed") && !have($item`shaking 4-d camera`)) {
-              retrieveItem($item`4-d camera`);
-            }
-            useFamiliar($familiar`Pocket Professor`);
-            meatOutfit(true);
-            withMacro(
-              Macro.if_(
-                "!hasskill Lecture on Relativity",
-                Macro.trySkill("Digitize").externalIf(
-                  !get("_cameraUsed") && !have($item`shaking 4-d camera`),
-                  Macro.tryItem("4-d camera")
-                )
-              )
-                .trySkill("Lecture on Relativity")
-                .meatKill(),
-              () => use($item`photocopied monster`)
-            );
-          }
-
-          if (
-            getCounters("Digitize Monster", 0, 100).trim() === "" &&
-            get("_mushroomGardenFights") === 0
-          ) {
-            if (have($item`packet of mushroom spores`)) use($item`packet of mushroom spores`);
-            // adventure in mushroom garden to start digitize timer.
-            freeFightOutfit();
-            useFamiliar(meatFamiliar());
-            adventureMacro($location`Your Mushroom Garden`, Macro.meatKill());
-          }
-
-          // Second round of prof copies with familiar weight on.
-          freeFightMood().execute(20);
-          useFamiliar($familiar`Pocket Professor`);
-          maximizeCached(["Familiar Weight"], { forceEquip: $items`Pocket Professor memory chip` });
-          withMacro(
-            Macro.if_("!hasskill Lecture on Relativity", Macro.trySkill("Meteor Shower"))
-              .trySkill("Lecture on Relativity")
-              .tryItem($item`Spooky Putty sheet`)
-              .meatKill(),
-            () => use($item`shaking 4-d camera`)
-          );
-          set("_garbo_professorLecturesUsed", true);
-        } else if (!get("_photocopyUsed")) {
-          withMacro(Macro.tryItem($item`Spooky Putty sheet`).meatKill(), () => {
-            use($item`photocopied monster`);
-          });
-          set("_garbo_professorLecturesUsed", true);
-        }
-
-        let puttyCount = 1;
-        while (availableAmount($item`Spooky Putty monster`) > 0 && puttyCount <= 5) {
-          useFamiliar(meatFamiliar());
-          meatOutfit(true);
-          withMacro(
-            Macro.externalIf(
-              get("spookyPuttyCopiesMade") < 5 && puttyCount < 5,
-              Macro.item($item`Spooky Putty sheet`)
-            ).meatKill(),
-            () => use($item`Spooky Putty monster`)
-          );
-          puttyCount++;
-        }
-        set("spookyPuttyCopiesMade", 5);
-      });
-    }
+  ensureEffect($effect`Peppermint Twisted`);
+  if (mySpleenUse() < spleenLimit()) ensureEffect($effect`Eau d' Clochard`);
+  if (mySpleenUse() < spleenLimit() && have($item`body spradium`)) {
+    ensureEffect($effect`Boxing Day Glow`);
   }
+  freeFightMood().execute(30);
+  withStash($items`Platinum Yendorian Express Card`, () => {
+    if (have($item`Platinum Yendorian Express Card`)) {
+      use($item`Platinum Yendorian Express Card`);
+    }
+  });
+  if (have($item`license to chill`) && !get("_licenseToChillUsed")) use($item`license to chill`);
+
+  if (SourceTerminal.have()) SourceTerminal.educate([$skill`Extract`, $skill`Digitize`]);
+  if (!get("_cameraUsed") && !have($item`shaking 4-d camera`)) {
+    retrieveItem($item`4-d camera`);
+  }
+}
+
+function getEmbezzlerFight(): EmbezzlerFight | null {
+  let potentials = false;
+  for (let fight of embezzlerSources) {
+    if (fight.available()) return fight;
+    if (fight.potential()) potentials = true;
+  }
+  if (
+    potentials &&
+    get("_genieFightsUsed") < 3 &&
+    userConfirm(
+      "Garbo has detected you have potential ways to copy an Embezzler, but no way to start a fight with one. Should we wish for an Embezzler?"
+    )
+  ) {
+    new EmbezzlerFight(
+      () => false,
+      () => 0,
+      () => {
+        retrieveItem($item`pocket wish`);
+        cliExecute("genie fight knob goblin embezzler");
+      }
+    );
+  }
+  return null;
+}
+
+export function dailyFights() {
+  withStash($items`Spooky putty sheet`, () => {
+    embezzlerSetup();
+
+    // FIRST EMBEZZLER CHAIN
+    if (have($familiar`Pocket Professor`) && !get<boolean>("_garbo_meatChain", false)) {
+      const fightSource = getEmbezzlerFight();
+      if (!fightSource) return;
+      useFamiliar($familiar`Pocket Professor`);
+      meatOutfit(true, [new Requirement([], { forceEquip: $items`Pocket Professor memory chip` })]);
+      withMacro(firstChainMacro(), () => fightSource.run($location`Noob Cave`));
+      set("_garbo_meatChain", true);
+    }
+
+    // START DIGITIZE IF APPLICABLE
+    if (
+      getCounters("Digitize Monster", 0, 100).trim() === "" &&
+      get("_mushroomGardenFights") === 0
+    ) {
+      if (have($item`packet of mushroom spores`)) use($item`packet of mushroom spores`);
+      // adventure in mushroom garden to start digitize timer.
+      freeFightOutfit();
+      useFamiliar(meatFamiliar());
+      adventureMacro($location`Your Mushroom Garden`, Macro.meatKill());
+    }
+
+    // SECOND EMBEZZLER CHAIN
+    if (have($familiar`Pocket Professor`) && !get<boolean>("_garbo_weightChain", false)) {
+      const fightSource = getEmbezzlerFight();
+      if (!fightSource) return;
+      useFamiliar($familiar`Pocket Professor`);
+      maximizeCached(["Familiar Weight"], { forceEquip: $items`Pocket Professor memory chip` });
+      withMacro(secondChainMacro(), () => fightSource.run($location`Noob Cave`));
+      set("_garbo_weightChain", true);
+    }
+
+    let nextFight = getEmbezzlerFight();
+    while (nextFight !== null) {
+      withMacro(embezzlerMacro(), () => {
+        if (nextFight) {
+          useFamiliar(meatFamiliar());
+          if (
+            nextFight.draggable &&
+            !get("_envyfishEggUsed") &&
+            (booleanModifier("Adventure Underwater") ||
+              $items`aerated diving helmet, crappy mer-kin mask, Mer-kin gladiator mask, Mer-kin scholar mask, old SCUBA tank, The Crown of Ed the Undying`.some(
+                have
+              )) &&
+            (booleanModifier("Underwater Familiar") ||
+              $items`little bitty bathysphere, das boot`.some(have)) &&
+            (have($effect`Fishy`) || (have($item`fishy pipe`) && !get("_fishyPipeUsed"))) &&
+            !have($item`envyfish egg`)
+          ) {
+            meatOutfit(true, [], true);
+            if (get("questS01OldGuy") === "unstarted") {
+              visitUrl("place.php?whichplace=sea_oldman&action=oldman_oldman");
+            }
+            retrieveItem($item`pulled green taffy`);
+            if (!have($effect`Fishy`)) use($item`fishy pipe`);
+            nextFight.run($location`The Briny Deeps`);
+          }
+          meatOutfit(true);
+          nextFight.run(prepWandererZone());
+        }
+      });
+      nextFight = getEmbezzlerFight();
+    }
+  });
 }
 
 type FreeFightOptions = {

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -301,7 +301,7 @@ function getEmbezzlerFight(): EmbezzlerFight | null {
       "Garbo has detected you have potential ways to copy an Embezzler, but no way to start a fight with one. Should we wish for an Embezzler?"
     )
   ) {
-    new EmbezzlerFight(
+    return new EmbezzlerFight(
       () => false,
       () => 0,
       () => {

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -208,6 +208,32 @@ const embezzlerSources = [
   ),
   new EmbezzlerFight(
     () =>
+      have($item`shaking 4-d camera`) &&
+      get("cameraMonster") === $monster`Knob Goblin Embezzler` &&
+      !get("_cameraUsed"),
+    () =>
+      have($item`shaking 4-d camera`) &&
+      get("cameraMonster") === $monster`Knob Goblin Embezzler` &&
+      !get("_cameraUsed")
+        ? 1
+        : 0,
+    () => use($item`shaking 4-d camera`)
+  ),
+  new EmbezzlerFight(
+    () =>
+      have($item`envyfish egg`) &&
+      get("envyfishMonster") === $monster`Knob Goblin Embezzler` &&
+      !get("_envyfishEggUsed"),
+    () =>
+      have($item`envyfish egg`) &&
+      get("envyfishMonster") === $monster`Knob Goblin Embezzler` &&
+      !get("_envyfishEggUsed")
+        ? 1
+        : 0,
+    () => use($item`envyfish egg`)
+  ),
+  new EmbezzlerFight(
+    () =>
       get("lastCopyableMonster") === $monster`Knob Goblin Embezzler` &&
       have($item`backup camera`) &&
       get<number>("_backUpUses") < 11,

--- a/src/index.ts
+++ b/src/index.ts
@@ -300,24 +300,6 @@ function barfTurn() {
     cliExecute("retrocape robot kill");
   }
 
-  while (
-    get<Monster>("lastCopyableMonster") === $monster`Knob Goblin Embezzler` &&
-    have($item`backup camera`) &&
-    get<number>("_backUpUses") < 11
-  ) {
-    if (have($effect`beaten up`))
-      throw "Hey, you're beaten up, and that's a bad thing. Lick your wounds, handle your problems, and run me again when you feel ready.";
-    useFamiliar(meatFamiliar());
-    meatOutfit(true, [new Requirement([], { forceEquip: $items`backup camera` })]);
-    adventureMacro(
-      $location`Noob Cave`,
-      Macro.if_(
-        "!monstername Knob Goblin Embezzler",
-        Macro.skill("Back-Up to Your Last Enemy")
-      ).meatKill()
-    );
-  }
-
   // a. set up familiar
   useFamiliar(meatFamiliar());
 

--- a/src/mood.ts
+++ b/src/mood.ts
@@ -2,6 +2,7 @@ import {
   buy,
   cliExecute,
   getCampground,
+  getClanLounge,
   getFuel,
   haveEffect,
   haveSkill,
@@ -107,6 +108,10 @@ export function freeFightMood() {
     if (have($item`Glenn's golden dice`)) use($item`Glenn's golden dice`);
   }
 
+  if (getClanLounge()["Clan pool table"] !== undefined) {
+    while (get("_poolGames") < 3) cliExecute("pool aggressive");
+  }
+
   if (haveEffect($effect`Blue Swayed`) < 50) {
     use(Math.ceil((50 - haveEffect($effect`Blue Swayed`)) / 10), $item`pulled blue taffy`);
   }
@@ -114,7 +119,6 @@ export function freeFightMood() {
 
   // FIXME: Figure out what's actually good!
   if (!have($effect`Frosty`) && mallPrice($item`frost flower`) < 70000) {
-    if (!get("_freePillKeeperUsed")) cliExecute("pillkeeper extend");
     if (!have($item`frost flower`)) buy($item`frost flower`);
     use($item`frost flower`);
   }

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -1,7 +1,6 @@
 import {
   myInebriety,
   inebrietyLimit,
-  useFamiliar,
   myFamiliar,
   myClass,
   retrieveItem,
@@ -137,6 +136,6 @@ export function meatOutfit(embezzlerUp: boolean, requirements: Requirement[] = [
   if (equippedAmount($item`ice nine`) > 0) {
     equip($item`unwrapped retro superhero cape`);
   }
-  if ((sea && !booleanModifier("Adventure Underwater")) || !booleanModifier("Underwater Familiar"))
+  if (sea && (!booleanModifier("Adventure Underwater") || !booleanModifier("Underwater Familiar")))
     maximizeCached(["sea -tie"]);
 }

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -8,6 +8,7 @@ import {
   equippedAmount,
   equip,
   totalTurnsPlayed,
+  booleanModifier,
 } from "kolmafia";
 import {
   $class,
@@ -136,5 +137,6 @@ export function meatOutfit(embezzlerUp: boolean, requirements: Requirement[] = [
   if (equippedAmount($item`ice nine`) > 0) {
     equip($item`unwrapped retro superhero cape`);
   }
-  if (sea) maximizeCached(["sea -tie"]);
+  if ((sea && !booleanModifier("Adventure Underwater")) || !booleanModifier("Underwater Familiar"))
+    maximizeCached(["sea -tie"]);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2146,11 +2146,6 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-he@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
-  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
-
 human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
@@ -2488,15 +2483,14 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
-libram@^0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/libram/-/libram-0.0.8.tgz#d41184d8b6264e638b8e728aac7567084bd10986"
-  integrity sha512-R/SmxCFkjlfl0Cwk9P0y38FdZUGT+rz2NPMLhCinoQXJMR8DbLwwPCDEgvMZlprrCKCu+9scQEcv33qUu6jaNA==
+libram@^0.0.9:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/libram/-/libram-0.0.9.tgz#c811545a4b645e3414ffe87c17d729d8df014fad"
+  integrity sha512-BjN2Vj7sYIrkcy4FS28s7Q/G4K4FFlwnOpGyQNjDELBM3qzsAEKNvFB79SQgvPeLorPGBJG6xg3jkCHQtQCgIw==
   dependencies:
     core-js "3.9.0"
     kolmafia "^1.0.3"
     lodash-es "^4.17.21"
-    node-html-parser "^2.0.0"
 
 loader-runner@^4.2.0:
   version "4.2.0"
@@ -2688,13 +2682,6 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
-
-node-html-parser@^2.0.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-2.2.1.tgz#6507a8658810d1612890a8ddd534e01b2f97e07e"
-  integrity sha512-Vccqb62t6t7DkMVwqPQgb0NWO+gUMMDm+1X3LzqbtXLqjilCTtUYTlniKk08yuA1zIhEFVzu/dozpqs5KZbRFQ==
-  dependencies:
-    he "1.2.0"
 
 node-releases@^1.1.71:
   version "1.1.73"


### PR DESCRIPTION
Major upshot of this change is we should now be better at handling envyfish eggs without digitize and starting embezzler chains without VIP key or with the day's photocopy already used, as well as genericizing the interface to make adding more copies later easier.

Hopefully.