### PR TITLE
fix small eldritch tentacle fight bug

### DIFF
--- a/src/fights.ts
+++ b/src/fights.ts
@@ -519,7 +519,7 @@ const freeFightSources = [
   new FreeFight(
     () => get("questL02Larva") !== "unstarted" && !get("_eldritchTentacleFought"),
     () => {
-      const haveEldritchEssence = have($item`eldritch essence`);
+      const haveEldritchEssence = itemAmount($item`eldritch essence`) !== 0;
       visitUrl("place.php?whichplace=forestvillage&action=fv_scientist", false);
       if (!handlingChoice()) throw "No choice?";
       runChoice(haveEldritchEssence ? 2 : 1);


### PR DESCRIPTION
Previously on gossip girl, it would check with have() for eldritch essence, which uses availableAmount(), which checks closet and hagnks. We care only about items in inventory, and thus must use itemAmount().