### PR TITLE
Only use borrowed time if ascending

### DIFF
--- a/src/diet.ts
+++ b/src/diet.ts
@@ -35,6 +35,7 @@ import {
   useFamiliar,
 } from "kolmafia";
 import { $class, $effect, $item, $items, $skill, get, have, $familiar, set } from "libram";
+import { globalOptions } from ".";
 import { clamp, ensureEffect } from "./lib";
 
 const MPA = get("valueOfAdventure");
@@ -303,7 +304,8 @@ export function runDiet(): void {
     useSkill(casts, $skill`Ancestral Recall`);
   }
 
-  useIfUnused($item`borrowed time`, "_borrowedTimeUsed", 5 * MPA);
+  if (globalOptions.ascending) useIfUnused($item`borrowed time`, "_borrowedTimeUsed", 5 * MPA);
+
   fillSomeSpleen();
   fillStomach();
   fillLiver();

--- a/src/diet.ts
+++ b/src/diet.ts
@@ -152,7 +152,6 @@ function useIfUnused(item: Item, prop: string | boolean, maxPrice: number) {
   }
 }
 
-const snuff = $item`voodoo snuff`;
 const valuePerSpleen = (item: Item) => -(adventureGain(item) * MPA - mallPrice(item)) / item.spleen;
 let savedBestSpleenItem: Item | null = null;
 let savedPotentialSpleenItems: Item[] | null = null;
@@ -287,6 +286,10 @@ export function runDiet(): void {
     5 * MPA + 5000
   );
   useIfUnused($item`essential tofu`, "_essentialTofuUsed", 5 * MPA);
+
+  if (!get("_etchedHourglassUsed") && have($item`etched hourglass`)) {
+    use(1, $item`etched hourglass`);
+  }
 
   if (getProperty("_timesArrowUsed") !== "true" && mallPrice($item`time's arrow`) < 5 * MPA) {
     acquire(1, $item`time's arrow`, 5 * MPA);

--- a/src/index.ts
+++ b/src/index.ts
@@ -179,8 +179,9 @@ function barfTurn() {
   }
 }
 
-export const globalOptions: { stopTurncount: number | null } = {
+export const globalOptions: { ascending: boolean; stopTurncount: number | null } = {
   stopTurncount: null,
+  ascending: false,
 };
 
 export function canContinue() {
@@ -208,6 +209,9 @@ export function main(argString = "") {
   for (const arg of args) {
     if (arg.match(/\d+/)) {
       globalOptions.stopTurncount = myTurncount() + parseInt(arg, 10);
+    }
+    if (arg.match(/ascend/)) {
+      globalOptions.ascending = true;
     }
   }
   const gardens = $items`packet of pumpkin seeds, Peppermint Pip Packet, packet of dragon's teeth, packet of beer seeds, packet of winter seeds, packet of thanksgarden seeds, packet of tall grass seeds, packet of mushroom spores`;


### PR DESCRIPTION
Adds the ascending global option (defaulting to false) that determines if we should attempt to use borrowed time. Also, adds etched hourglass use.