### PR TITLE
Added missing parenthesis check for bander ode check/call.

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -309,8 +309,8 @@ const freeRuns: freeRun[] = [
 
   new freeRun(
     () =>
-      ((have($familiar`frumious bandersnatch`) && have($effect`ode to booze`)) ||
-        getSongCount() < getSongLimit() ||
+      ((have($familiar`frumious bandersnatch`) && (have($effect`ode to booze`)) ||
+        getSongCount() < getSongLimit()) ||
         have($familiar`pair of stomping boots`)) &&
       Bandersnatch.getRemainingRunaways() > 0,
     () => {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -309,8 +309,8 @@ const freeRuns: freeRun[] = [
 
   new freeRun(
     () =>
-      ((have($familiar`frumious bandersnatch`) && (have($effect`ode to booze`)) ||
-        getSongCount() < getSongLimit()) ||
+      ((have($familiar`frumious bandersnatch`) &&
+        (have($effect`ode to booze`) || getSongCount() < getSongLimit())) ||
         have($familiar`pair of stomping boots`)) &&
       Bandersnatch.getRemainingRunaways() > 0,
     () => {


### PR DESCRIPTION
I was getting an error message about not having a pair of stomping boots (this is true).  After looking at the code, I suspect that the free run logic is missing a parenthesis for the bandersnatch + ode check.  I didn't get to test this fix since I had run out of adv by the time I got around to looking at the error.