### PR TITLE
Pick bjorn familiars based on drops and enchantment, rather than just enchantment

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -264,7 +264,7 @@ export function main(argString = "") {
     }
 
     // FIXME: Dynamically figure out pointer ring approach.
-    withStash($items`haiku katana, repaid diaper`, () => {
+    withStash($items`haiku katana, repaid diaper, buddy bjorn`, () => {
       // 0. diet stuff.
       runDiet();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -264,7 +264,7 @@ export function main(argString = "") {
     }
 
     // FIXME: Dynamically figure out pointer ring approach.
-    withStash($items`haiku katana, repaid diaper, buddy bjorn`, () => {
+    withStash($items`haiku katana, repaid diaper, buddy bjorn, crown of thrones`, () => {
       // 0. diet stuff.
       runDiet();
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -298,7 +298,9 @@ const freeRuns: freeRun[] = [
     () => {
       if (getWorkshed() !== $item`Asdon Martin keyfob`) return false;
       const banishes = get("banishedMonsters").split(":");
-      const bumperIndex = banishes.map((string) => string.toLowerCase()).indexOf("spring-loaded front bumper");
+      const bumperIndex = banishes
+        .map((string) => string.toLowerCase())
+        .indexOf("spring-loaded front bumper");
       if (bumperIndex === -1) return true;
       return myTurncount() - parseInt(banishes[bumperIndex + 1]) > 30;
     },
@@ -361,8 +363,15 @@ const freeRuns: freeRun[] = [
 export function findRun() {
   return freeRuns.find((run) => run.available());
 }
-function averageValue(items: Item[]) {
-  return items.map((item) => mallPrice(item)).reduce((x, price) => x + price, 0) / items.length;
+function trueValue(...items: Item[]) {
+  return items
+    .map((item) => {
+      if (!item.discardable) {
+        return mallPrice(item) > 2 * autosellPrice(item) ? mallPrice(item) : autosellPrice(item);
+      }
+      return mallPrice(item) > 100 ? mallPrice(item) : 0;
+    })
+    .reduce((s, price) => s + price, 0) / items.length;
 }
 interface famPick {
   familiar: Familiar;
@@ -373,73 +382,73 @@ interface famPick {
 const bjornFams = [
   {
     familiar: $familiar`puck man`,
-    meatVal: mallPrice($item`yellow pixel`),
+    meatVal: trueValue($item`yellow pixel`),
     probability: () => (get("_yellowPixelDropsCrown") < 25 ? 0.25 : 0),
   },
   {
     familiar: $familiar`grimstone golem`,
-    meatVal: mallPrice($item`grimstone mask`),
+    meatVal: trueValue($item`grimstone mask`),
     probability: () => (get("_grimstoneMaskDropsCrown") === 0 ? 0.5 : 0),
   },
   { familiar: $familiar`Knob Goblin Organ Grinder`, meatVal: 30, probability: () => 1 },
   {
     familiar: $familiar`garbage fire`,
-    meatVal: mallPrice($item`burning newspaper`),
+    meatVal: trueValue($item`burning newspaper`),
     probability: () => (get("_garbageFireDropsCrown") < 3 ? 0.5 : 0),
   },
   {
     familiar: $familiar`machine elf`,
-    meatVal: averagePrice(
-      $items`abstraction: thought, abstraction: action, abstraction: category, abstraction: perception, abstraction: purpose`
+    meatVal: trueValue(
+      ...$items`abstraction: thought, abstraction: action, abstraction: category, abstraction: perception, abstraction: purpose`
     ),
     probability: () => (get("_abstractionDropsCrown") < 25 ? 0.2 : 0),
   },
   {
     familiar: $familiar`trick-or-treating tot`,
-    meatVal: mallPrice($item`hoarded candy wad`),
+    meatVal: trueValue($item`hoarded candy wad`),
     probability: () => (get("_hoardedCandyDropsCrown") < 3 ? 0.5 : 0),
   },
   {
     familiar: $familiar`warbear drone`,
-    meatVal: mallPrice($item`warbear whosit`),
+    meatVal: trueValue($item`warbear whosit`),
     probability: () => 1 / 4.5,
   },
   {
     familiar: $familiar`li'l xenomorph`,
-    meatVal: mallPrice($item`lunar isotope`),
+    meatVal: trueValue($item`lunar isotope`),
     probability: () => 0.05,
   },
   {
     familiar: $familiar`pottery barn owl`,
-    meatVal: mallPrice($item`volcanic ash`),
+    meatVal: trueValue($item`volcanic ash`),
     probability: () => 0.1,
   },
   {
     familiar: $familiar`grim brother`,
-    meatVal: mallPrice($item`grim fairy tale`),
+    meatVal: trueValue($item`grim fairy tale`),
     probability: () => (get("_grimFairyTaleDropsCrown") < 2 ? 1 : 0),
   },
   {
     familiar: $familiar`optimistic candle`,
-    meatVal: mallPrice($item`glob of melted wax`),
+    meatVal: trueValue($item`glob of melted wax`),
     probability: () => (get("_optimisticCandleDropsCrown") < 3 ? 1 : 0),
   },
   {
     familiar: $familiar`Adventurous Spelunker`,
-    meatVal: averagePrice(
-      $items`teflon ore, Velcro ore, Vinyl ore, cardboard ore, styrofoam ore, bubblewrap ore`
+    meatVal: trueValue(
+      ...$items`teflon ore, Velcro ore, Vinyl ore, cardboard ore, styrofoam ore, bubblewrap ore`
     ),
     probability: () => (get("_oreDropsCrown") < 6 ? 1 : 0),
   },
   {
     familiar: $familiar`Twitching Space Critter`,
-    meatVal: mallPrice($item`space beast fur`),
+    meatVal: trueValue($item`space beast fur`),
     probability: () => (get("_spaceFurDropsCrown") < 1 ? 1 : 0),
   },
   {
     familiar: $familiar`party mouse`,
-    meatVal: averagePrice(
-      Item.all().filter(
+    meatVal: trueValue(
+      ...Item.all().filter(
         (booze) =>
           ["decent", "good"].includes(booze.quality) &&
           booze.inebriety > 0 &&
@@ -454,12 +463,12 @@ const bjornFams = [
   },
   {
     familiar: $familiar`yule hound`,
-    meatVal: mallPrice($item`candy cane`),
+    meatVal: trueValue($item`candy cane`),
     probability: () => 1,
   },
   {
     familiar: $familiar`gluttonous green ghost`,
-    meatVal: averagePrice($items`bean burrito, enchanted bean burrito, jumping bean burrito`),
+    meatVal: trueValue(...$items`bean burrito, enchanted bean burrito, jumping bean burrito`),
     probability: () => 1,
   },
   {
@@ -469,24 +478,24 @@ const bjornFams = [
   },
   {
     familiar: $familiar`Hunchbacked Minion`,
-    meatVal: averagePrice($items`176,163,163,163,163`),
+    meatVal: trueValue(...$items`176,163,163,163,163`),
     probability: () => 1,
   },
   {
     familiar: $familiar`reanimated reanimator`,
-    meatVal: averagePrice($items`hot wing,broken skull`),
+    meatVal: trueValue(...$items`hot wing,broken skull`),
     probability: () => 1,
   },
   {
     familiar: $familiar`attention-deficit demon`,
-    meatVal: averagePrice(
-      $items`chorizo brownies,white chocolate and tomato pizza,carob chunk noodles`
+    meatVal: trueValue(
+      ...$items`chorizo brownies,white chocolate and tomato pizza,carob chunk noodles`
     ),
     probability: () => 1,
   },
   {
     familiar: $familiar`piano cat`,
-    meatVal: averagePrice($items`beertini,papaya slung,salty slug,tomato daiquiri`),
+    meatVal: trueValue(...$items`beertini,papaya slung,salty slug,tomato daiquiri`),
     probability: () => 1,
   },
   {
@@ -496,57 +505,57 @@ const bjornFams = [
   },
   {
     familiar: $familiar`robot reindeer`,
-    meatVal: averageValue($items`candy cane,eggnog,fruitcake,gingerbread bugbear`),
+    meatVal: trueValue(...$items`candy cane,eggnog,fruitcake,gingerbread bugbear`),
     probability: () => 0.3,
   },
   {
     familiar: $familiar`stocking mimic`,
-    meatVal: averageValue($items`540,617,906,908,909`),
+    meatVal: trueValue(...$items`540,617,906,908,909`),
     probability: () => 0.3,
   },
   {
     familiar: $familiar`BRICKO chick`,
-    meatVal: autosellPrice($item`BRICKO brick`),
+    meatVal: trueValue($item`BRICKO brick`),
     probability: () => 1,
   },
   {
     familiar: $familiar`Cotton Candy Carnie`,
-    meatVal: mallPrice($item`cotton candy pinch`),
+    meatVal: trueValue($item`cotton candy pinch`),
     probability: () => 1,
   },
   {
     familiar: $familiar`untamed turtle`,
-    meatVal: averageValue($items`snailmail bits,turtlemail bits,turtle wax`),
+    meatVal: trueValue(...$items`snailmail bits,turtlemail bits,turtle wax`),
     probability: () => 0.35,
   },
   {
     familiar: $familiar`astral badger`,
-    meatVal: 2 * averageValue($items`spooky mushroom, knob mushroom, knoll mushroom`),
+    meatVal: 2 * trueValue(...$items`spooky mushroom, knob mushroom, knoll mushroom`),
     probability: () => 1,
   },
   {
     familiar: $familiar`green pixie`,
-    meatVal: mallPrice($item`bottle of tequila`),
+    meatVal: trueValue($item`bottle of tequila`),
     probability: () => 0.2,
   },
   {
     familiar: $familiar`angry goat`,
-    meatVal: autosellPrice($item`goat cheese pizza`),
+    meatVal: trueValue($item`goat cheese pizza`),
     probability: () => 1,
   },
   {
     familiar: $familiar`adorable seal larva`,
-    meatVal: averageValue($items`1445,1446,1447,1448,1449`),
+    meatVal: trueValue(...$items`1445,1446,1447,1448,1449`),
     probability: () => 0.35,
   },
   {
     familiar: $familiar`ancient yuletide troll`,
-    meatVal: averageValue($items`candy cane,eggnog,fruitcake,gingerbread bugbear`),
+    meatVal: trueValue(...$items`candy cane,eggnog,fruitcake,gingerbread bugbear`),
     probability: () => 0.3,
   },
   {
     familiar: $familiar`sweet nutcracker`,
-    meatVal: averageValue($items`candy cane,eggnog,fruitcake,gingerbread bugbear`),
+    meatVal: trueValue(...$items`candy cane,eggnog,fruitcake,gingerbread bugbear`),
     probability: () => 0.3,
   },
 ];

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -554,5 +554,6 @@ const bjornFams = [
 export function pickBjorn() {
   return bjornFams
     .filter((bjornFam) => have(bjornFam.familiar))
+    .filter((bjornFam) => myFamiliar() !== bjornFam.familiar)
     .sort((a, b) => a.meatVal * a.probability() - b.meatVal * b.probability())[0];
 }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -458,7 +458,7 @@ const bjornFams = [
     probability: () => 1,
   },
   {
-    familiar: $familiar`gluttinous green ghost`,
+    familiar: $familiar`gluttonous green ghost`,
     meatVal: averagePrice($items`bean burrito, enchanted bean burrito, jumping bean burrito`),
     probability: () => 1,
   },
@@ -515,7 +515,7 @@ const bjornFams = [
     probability: () => 1,
   },
   {
-    familiar: $familiar`unnamed turtle`,
+    familiar: $familiar`untamed turtle`,
     meatVal: averageValue($items`snailmail bits,turtlemail bits,turtle wax`),
     probability: () => 0.35,
   },

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -374,169 +374,187 @@ interface famPick {
 
 const bjornFams = [
   {
-      familiar: $familiar`puck man`,
-      meatVal: mallPrice($item`yellow pixel`),
-      probability: () => (get("_yellowPixelDropsCrown") < 25 ? 0.25 : 0),
+    familiar: $familiar`puck man`,
+    meatVal: mallPrice($item`yellow pixel`),
+    probability: () => (get("_yellowPixelDropsCrown") < 25 ? 0.25 : 0),
   },
   {
-      familiar: $familiar`grimstone golem`,
-      meatVal: mallPrice($item`grimstone mask`),
-      probability: () => (get("_grimstoneMaskDropsCrown") === 0 ? 0.5 : 0),
+    familiar: $familiar`grimstone golem`,
+    meatVal: mallPrice($item`grimstone mask`),
+    probability: () => (get("_grimstoneMaskDropsCrown") === 0 ? 0.5 : 0),
   },
   { familiar: $familiar`Knob Goblin Organ Grinder`, meatVal: 30, probability: () => 1 },
   {
-      familiar: $familiar`garbage fire`,
-      meatVal: mallPrice($item`burning newspaper`),
-      probability: () => (get("_garbageFireDropsCrown") < 3 ? 0.5 : 0),
+    familiar: $familiar`garbage fire`,
+    meatVal: mallPrice($item`burning newspaper`),
+    probability: () => (get("_garbageFireDropsCrown") < 3 ? 0.5 : 0),
   },
   {
-      familiar: $familiar`machine elf`,
-      meatVal:
-         averagePrice($items`abstraction: thought, abstraction: action, abstraction: category, abstraction: perception, abstraction: purpose`),
-      probability: () => (get("_abstractionDropsCrown") < 25 ? 0.2 : 0),
+    familiar: $familiar`machine elf`,
+    meatVal: averagePrice(
+      $items`abstraction: thought, abstraction: action, abstraction: category, abstraction: perception, abstraction: purpose`
+    ),
+    probability: () => (get("_abstractionDropsCrown") < 25 ? 0.2 : 0),
   },
   {
-      familiar: $familiar`trick-or-treating tot`,
-      meatVal: mallPrice($item`hoarded candy wad`),
-      probability: () => (get("_hoardedCandyDropsCrown") < 3 ? 0.5 : 0),
+    familiar: $familiar`trick-or-treating tot`,
+    meatVal: mallPrice($item`hoarded candy wad`),
+    probability: () => (get("_hoardedCandyDropsCrown") < 3 ? 0.5 : 0),
   },
   {
-      familiar: $familiar`warbear drone`,
-      meatVal: mallPrice($item`warbear whosit`),
-      probability: () => 1 / 4.5,
+    familiar: $familiar`warbear drone`,
+    meatVal: mallPrice($item`warbear whosit`),
+    probability: () => 1 / 4.5,
   },
   {
-      familiar: $familiar`li'l xenomorph`,
-      meatVal: mallPrice($item`lunar isotope`),
-      probability: () => 0.05,
+    familiar: $familiar`li'l xenomorph`,
+    meatVal: mallPrice($item`lunar isotope`),
+    probability: () => 0.05,
   },
   {
-      familiar: $familiar`pottery barn owl`,
-      meatVal: mallPrice($item`volcanic ash`),
-      probability: () => 0.1,
+    familiar: $familiar`pottery barn owl`,
+    meatVal: mallPrice($item`volcanic ash`),
+    probability: () => 0.1,
   },
   {
     familiar: $familiar`grim brother`,
     meatVal: mallPrice($item`grim fairy tale`),
-    probability: () => get("_grimFairyTaleDropsCrown") < 2 ? 1 : 0
+    probability: () => (get("_grimFairyTaleDropsCrown") < 2 ? 1 : 0),
   },
   {
     familiar: $familiar`optimistic candle`,
     meatVal: mallPrice($item`glob of melted wax`),
-    probability: () => get("_optimisticCandleDropsCrown") < 3 ? 1 : 0
+    probability: () => (get("_optimisticCandleDropsCrown") < 3 ? 1 : 0),
   },
   {
     familiar: $familiar`Adventurous Spelunker`,
-    meatVal: averagePrice($items`teflon ore, Velcro ore, Vinyl ore, cardboard ore, styrofoam ore, bubblewrap ore`),
-    probability: () => get("_oreDropsCrown") < 6 ? 1 : 0,
+    meatVal: averagePrice(
+      $items`teflon ore, Velcro ore, Vinyl ore, cardboard ore, styrofoam ore, bubblewrap ore`
+    ),
+    probability: () => (get("_oreDropsCrown") < 6 ? 1 : 0),
   },
   {
     familiar: $familiar`Twitching Space Critter`,
     meatVal: mallPrice($item`space beast fur`),
-    probability: () => get("_spaceFurDropsCrown") < 1 ? 1 : 0
+    probability: () => (get("_spaceFurDropsCrown") < 1 ? 1 : 0),
   },
   {
     familiar: $familiar`party mouse`,
-    meatVal: averagePrice(Item.all().filter((booze) => ["decent", "good"].includes(booze.quality) && booze.inebriety > 0 && booze.tradeable && booze.discardable && !$items`glass of "milk", cup of "tea", thermos of "whiskey", Lucky Lindy, Bee's Knees, Sockdollager, Ish Kabibble, Hot Socks, Phonus Balonus, Flivver, Sloppy Jalopy`.includes(booze))),
-    probability: () => 0.05
+    meatVal: averagePrice(
+      Item.all().filter(
+        (booze) =>
+          ["decent", "good"].includes(booze.quality) &&
+          booze.inebriety > 0 &&
+          booze.tradeable &&
+          booze.discardable &&
+          !$items`glass of "milk", cup of "tea", thermos of "whiskey", Lucky Lindy, Bee's Knees, Sockdollager, Ish Kabibble, Hot Socks, Phonus Balonus, Flivver, Sloppy Jalopy`.includes(
+            booze
+          )
+      )
+    ),
+    probability: () => 0.05,
   },
   {
     familiar: $familiar`yule hound`,
     meatVal: mallPrice($item`candy cane`),
-    probability: () => 1
+    probability: () => 1,
   },
   {
     familiar: $familiar`gluttinous green ghost`,
     meatVal: averagePrice($items`bean burrito, enchanted bean burrito, jumping bean burrito`),
-    probability: () => 1
+    probability: () => 1,
   },
   {
     familiar: $familiar`Reassembled Blackbird`,
     meatVal: mallPrice($item`blackberry`),
-    probability: () => 1
+    probability: () => 1,
   },
   {
     familiar: $familiar`Hunchbacked Minion`,
     meatVal: averagePrice($items`176,163,163,163,163`),
-    probability: () => 1
+    probability: () => 1,
   },
   {
     familiar: $familiar`reanimated reanimator`,
     meatVal: averagePrice($items`hot wing,broken skull`),
-    probability: () => 1
+    probability: () => 1,
   },
   {
     familiar: $familiar`attention-deficit demon`,
-    meatVal: averagePrice($items`chorizo brownies,white chocolate and tomato pizza,carob chunk noodles`),
-    probability: () => 1
+    meatVal: averagePrice(
+      $items`chorizo brownies,white chocolate and tomato pizza,carob chunk noodles`
+    ),
+    probability: () => 1,
   },
   {
     familiar: $familiar`piano cat`,
     meatVal: averagePrice($items`beertini,papaya slung,salty slug,tomato daiquiri`),
-    probability: () => 1
+    probability: () => 1,
   },
   {
     familiar: $familiar`golden monkey`,
     meatVal: 100,
-    probability: () => 0.5
+    probability: () => 0.5,
   },
   {
     familiar: $familiar`robot reindeer`,
     meatVal: averageValue($items`candy cane,eggnog,fruitcake,gingerbread bugbear`),
-    probability: () => 0.3
+    probability: () => 0.3,
   },
   {
-  familiar: $familiar`stocking mimic`,
-  meatVal: averageValue($items`540,617,906,908,909`),
-  probability: () => 0.3
+    familiar: $familiar`stocking mimic`,
+    meatVal: averageValue($items`540,617,906,908,909`),
+    probability: () => 0.3,
   },
   {
     familiar: $familiar`BRICKO chick`,
     meatVal: autosellPrice($item`BRICKO brick`),
-    probability: () => 1
+    probability: () => 1,
   },
   {
     familiar: $familiar`Cotton Candy Carnie`,
     meatVal: mallPrice($item`cotton candy pinch`),
-    probability: () => 1
+    probability: () => 1,
   },
   {
     familiar: $familiar`unnamed turtle`,
     meatVal: averageValue($items`snailmail bits,turtlemail bits,turtle wax`),
-    probability: () => 0.35
+    probability: () => 0.35,
   },
   {
     familiar: $familiar`astral badger`,
     meatVal: 2 * averageValue($items`spooky mushroom, knob mushroom, knoll mushroom`),
-    probability: () => 1
+    probability: () => 1,
   },
-{
-  familiar: $familiar`green pixie`,
-  meatVal: mallPrice($item`bottle of tequila`),
-  probability: () => 0.2
-},
-{
-  familiar: $familiar`angry goat`,
-  meatVal: mallPrice($item`goat cheese pizza`),
-  probability: () => 1
-},
-{
-  familiar: $familiar`adorable seal larva`,
-  meatVal: averageValue($items`1445,1446,1447,1448,1449`),
-  probability: () => 0.35
-},
-{
-  familiar: $familiar`ancient yuletide troll`,
-  meatVal: averageValue($items`candy cane,eggnog,fruitcake,gingerbread bugbear`),
-  probability: () => 0.3
-},
-{
-  familiar: $familiar`sweet nutcracker`,
-  meatVal: averageValue($items`candy cane,eggnog,fruitcake,gingerbread bugbear`),
-  probability: () => 0.3
-}
+  {
+    familiar: $familiar`green pixie`,
+    meatVal: mallPrice($item`bottle of tequila`),
+    probability: () => 0.2,
+  },
+  {
+    familiar: $familiar`angry goat`,
+    meatVal: mallPrice($item`goat cheese pizza`),
+    probability: () => 1,
+  },
+  {
+    familiar: $familiar`adorable seal larva`,
+    meatVal: averageValue($items`1445,1446,1447,1448,1449`),
+    probability: () => 0.35,
+  },
+  {
+    familiar: $familiar`ancient yuletide troll`,
+    meatVal: averageValue($items`candy cane,eggnog,fruitcake,gingerbread bugbear`),
+    probability: () => 0.3,
+  },
+  {
+    familiar: $familiar`sweet nutcracker`,
+    meatVal: averageValue($items`candy cane,eggnog,fruitcake,gingerbread bugbear`),
+    probability: () => 0.3,
+  },
 ];
 
 export function pickBjorn() {
-  return bjornFams.filter((bjornFam) => have(bjornFam.familiar)).sort((a, b) => a.meatVal * a.probability() - b.meatVal * b.probability())[0]
+  return bjornFams
+    .filter((bjornFam) => have(bjornFam.familiar))
+    .sort((a, b) => a.meatVal * a.probability() - b.meatVal * b.probability())[0];
 }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -778,6 +778,24 @@ const bjornFams: BjornedFamiliar[] = [
       modifier: 10,
     },
   },
+  {
+    familiar: $familiar`misshapen animal skeleton`,
+    meatVal: 30,
+    probability: () => 1,
+    modifier: {
+      type: BjornModifierType.FMWT,
+      modifier: 5
+    }
+  },
+  {
+    familiar: $familiar`Gelatinous Cubeling`,
+    meatVal: 0,
+    probability: () => 0,
+    modifier: {
+      type: BjornModifierType.FMWT,
+      modifier: 5
+    }
+  }
 ];
 
 export enum PickBjornMode {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -297,7 +297,7 @@ const freeRuns: freeRun[] = [
   new freeRun(
     () => {
       if (getWorkshed() !== $item`Asdon Martin keyfob`) return false;
-      const banishes = get("banishedMonsters").split(":").map((string) => string.toLowerCase());
+      const banishes = get("banishedMonsters").split(":");
       const bumperIndex = banishes.indexOf("spring-loaded front bumper");
       if (bumperIndex === -1) return true;
       return myTurncount() - parseInt(banishes[bumperIndex + 1]) > 30;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -297,9 +297,7 @@ const freeRuns: freeRun[] = [
   new freeRun(
     () => {
       if (getWorkshed() !== $item`Asdon Martin keyfob`) return false;
-      const banishes = get("banishedMonsters")
-        .split(":")
-        .map((string) => string.toLowerCase());
+      const banishes = get("banishedMonsters").split(":").map((string) => string.toLowerCase());
       const bumperIndex = banishes.indexOf("spring-loaded front bumper");
       if (bumperIndex === -1) return true;
       return myTurncount() - parseInt(banishes[bumperIndex + 1]) > 30;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -707,7 +707,7 @@ const bjornFams: BjornedFamiliar[] = [
     },
   },
   {
-    familiar: $familiar`psychadelic bear`,
+    familiar: $familiar`psychedelic bear`,
     meatVal: 0,
     probability: () => 0,
     modifier: {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -531,7 +531,7 @@ const bjornFams = [
   },
   {
     familiar: $familiar`angry goat`,
-    meatVal: mallPrice($item`goat cheese pizza`),
+    meatVal: autosellPrice($item`goat cheese pizza`),
     probability: () => 1,
   },
   {
@@ -555,5 +555,5 @@ export function pickBjorn() {
   return bjornFams
     .filter((bjornFam) => have(bjornFam.familiar))
     .filter((bjornFam) => myFamiliar() !== bjornFam.familiar)
-    .sort((a, b) => a.meatVal * a.probability() - b.meatVal * b.probability())[0];
+    .sort((b, a) => a.meatVal * a.probability() - b.meatVal * b.probability())[0];
 }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -821,9 +821,8 @@ export function pickBjorn(mode: PickBjornMode = PickBjornMode.FREE) {
       const lepMultiplier = numericModifier(meatFamiliar(), "Leprechaun", 1, Item.get("none"));
       const fairyMultiplier = numericModifier(meatFamiliar(), "Fairy", 1, Item.get("none"));
       return (
-        (meatVal * (10 * lepMultiplier + (75 * Math.sqrt(lepMultiplier)) / Math.sqrt(245)) +
-          itemVal *
-            (5 * fairyMultiplier + (5 * Math.sqrt(55 * fairyMultiplier)) / (2 * Math.sqrt(60)))) /
+        (meatVal * (10 * lepMultiplier + 5 * Math.sqrt(lepMultiplier)) +
+          itemVal * (5 * fairyMultiplier + 2.5 * Math.sqrt(fairyMultiplier))) /
         100
       );
     }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -403,7 +403,24 @@ const bjornFams: BjornedFamiliar[] = [
     meatVal: trueValue($item`grimstone mask`),
     probability: () => (get("_grimstoneMaskDropsCrown") === 0 ? 0.5 : 0),
   },
-  { familiar: $familiar`Knob Goblin Organ Grinder`, meatVal: 30, probability: () => 1 },
+  {
+    familiar: $familiar`Knob Goblin Organ Grinder`,
+    meatVal: 30,
+    probability: () => 1,
+    modifier: {
+      type: BjornModifierType.MEAT,
+      modifier: 25,
+    },
+  },
+  {
+    familiar: $familiar`Happy Medium`,
+    meatVal: 30,
+    probability: () => 1,
+    modifier: {
+      type: BjornModifierType.MEAT,
+      modifier: 25,
+    },
+  },
   {
     familiar: $familiar`garbage fire`,
     meatVal: trueValue($item`burning newspaper`),
@@ -430,6 +447,10 @@ const bjornFams: BjornedFamiliar[] = [
     familiar: $familiar`li'l xenomorph`,
     meatVal: trueValue($item`lunar isotope`),
     probability: () => 0.05,
+    modifier: {
+      type: BjornModifierType.ITEM,
+      modifier: 15,
+    },
   },
   {
     familiar: $familiar`pottery barn owl`,
@@ -445,6 +466,10 @@ const bjornFams: BjornedFamiliar[] = [
     familiar: $familiar`optimistic candle`,
     meatVal: trueValue($item`glob of melted wax`),
     probability: () => (get("_optimisticCandleDropsCrown") < 3 ? 1 : 0),
+    modifier: {
+      type: BjornModifierType.ITEM,
+      modifier: 15,
+    },
   },
   {
     familiar: $familiar`Adventurous Spelunker`,
@@ -452,6 +477,10 @@ const bjornFams: BjornedFamiliar[] = [
       ...$items`teflon ore, Velcro ore, Vinyl ore, cardboard ore, styrofoam ore, bubblewrap ore`
     ),
     probability: () => (get("_oreDropsCrown") < 6 ? 1 : 0),
+    modifier: {
+      type: BjornModifierType.ITEM,
+      modifier: 15,
+    },
   },
   {
     familiar: $familiar`Twitching Space Critter`,
@@ -488,6 +517,19 @@ const bjornFams: BjornedFamiliar[] = [
     familiar: $familiar`Reassembled Blackbird`,
     meatVal: mallPrice($item`blackberry`),
     probability: () => 1,
+    modifier: {
+      type: BjornModifierType.ITEM,
+      modifier: 10,
+    },
+  },
+  {
+    familiar: $familiar`Reconstituted Crow`,
+    meatVal: mallPrice($item`blackberry`),
+    probability: () => 1,
+    modifier: {
+      type: BjornModifierType.ITEM,
+      modifier: 10,
+    },
   },
   {
     familiar: $familiar`Hunchbacked Minion`,
@@ -505,16 +547,28 @@ const bjornFams: BjornedFamiliar[] = [
       ...$items`chorizo brownies,white chocolate and tomato pizza,carob chunk noodles`
     ),
     probability: () => 1,
+    modifier: {
+      type: BjornModifierType.MEAT,
+      modifier: 20,
+    },
   },
   {
     familiar: $familiar`piano cat`,
     meatVal: trueValue(...$items`beertini,papaya slung,salty slug,tomato daiquiri`),
     probability: () => 1,
+    modifier: {
+      type: BjornModifierType.MEAT,
+      modifier: 20,
+    },
   },
   {
     familiar: $familiar`golden monkey`,
     meatVal: 100,
     probability: () => 0.5,
+    modifier: {
+      type: BjornModifierType.MEAT,
+      modifier: 25,
+    },
   },
   {
     familiar: $familiar`robot reindeer`,
@@ -571,6 +625,159 @@ const bjornFams: BjornedFamiliar[] = [
     meatVal: trueValue(...$items`candy cane,eggnog,fruitcake,gingerbread bugbear`),
     probability: () => 0.3,
   },
+  {
+    familiar: $familiar`casagnova gnome`,
+    meatVal: 0,
+    probability: () => 0,
+    modifier: {
+      type: BjornModifierType.MEAT,
+      modifier: 20,
+    },
+  },
+  {
+    familiar: $familiar`coffee pixie`,
+    meatVal: 0,
+    probability: () => 0,
+    modifier: {
+      type: BjornModifierType.MEAT,
+      modifier: 20,
+    },
+  },
+  {
+    familiar: $familiar`dancing frog`,
+    meatVal: 0,
+    probability: () => 0,
+    modifier: {
+      type: BjornModifierType.MEAT,
+      modifier: 20,
+    },
+  },
+  {
+    familiar: $familiar`grouper groupie`,
+    meatVal: 0,
+    probability: () => 0,
+    modifier: {
+      type: BjornModifierType.MEAT,
+      modifier: 20,
+    },
+  },
+  {
+    familiar: $familiar`hand turkey`,
+    meatVal: 30,
+    probability: () => 1,
+    modifier: {
+      type: BjornModifierType.MEAT,
+      modifier: 20,
+    },
+  },
+  {
+    familiar: $familiar`hippo ballerina`,
+    meatVal: 0,
+    probability: () => 0,
+    modifier: {
+      type: BjornModifierType.MEAT,
+      modifier: 20,
+    },
+  },
+  {
+    familiar: $familiar`jitterbug`,
+    meatVal: 0,
+    probability: () => 0,
+    modifier: {
+      type: BjornModifierType.MEAT,
+      modifier: 20,
+    },
+  },
+  {
+    familiar: $familiar`leprechaun`,
+    meatVal: 30,
+    probability: () => 1,
+    modifier: {
+      type: BjornModifierType.MEAT,
+      modifier: 20,
+    },
+  },
+  {
+    familiar: $familiar`obtuse angel`,
+    meatVal: 0,
+    probability: () => 0,
+    modifier: {
+      type: BjornModifierType.MEAT,
+      modifier: 20,
+    },
+  },
+  {
+    familiar: $familiar`psychadelic bear`,
+    meatVal: 0,
+    probability: () => 0,
+    modifier: {
+      type: BjornModifierType.MEAT,
+      modifier: 20,
+    },
+  },
+  {
+    familiar: $familiar`robortender`,
+    meatVal: 0,
+    probability: () => 0,
+    modifier: {
+      type: BjornModifierType.MEAT,
+      modifier: 20,
+    },
+  },
+  {
+    familiar: $familiar`ghost of crimbo commerce`,
+    meatVal: 30,
+    probability: () => 1,
+    modifier: {
+      type: BjornModifierType.MEAT,
+      modifier: 25,
+    },
+  },
+  {
+    familiar: $familiar`hobo monkey`,
+    meatVal: 0,
+    probability: () => 0,
+    modifier: {
+      type: BjornModifierType.MEAT,
+      modifier: 25,
+    },
+  },
+  {
+    familiar: $familiar`rockin' robin`,
+    meatVal: 60,
+    probability: () => 1,
+    modifier: {
+      type: BjornModifierType.ITEM,
+      modifier: 15,
+    },
+  },
+  {
+    familiar: $familiar`feral kobold`,
+    meatVal: 30,
+    probability: () => 1,
+    modifier: {
+      type: BjornModifierType.ITEM,
+      modifier: 15,
+    },
+  },
+  {
+    familiar: $familiar`oily woim`,
+    meatVal: 30,
+    probability: () => 1,
+    modifier: {
+      type: BjornModifierType.ITEM,
+      modifier: 10,
+    },
+  },
+  {
+    familiar: $familiar`cat burglar`,
+    meatVal: 0,
+    probability: () => 0,
+    modifier: {
+      type: BjornModifierType.ITEM,
+      modifier: 10,
+    },
+  },
 ];
 
 export enum PickBjornMode {
@@ -594,8 +801,7 @@ export function pickBjorn(mode: PickBjornMode = PickBjornMode.FREE) {
     return 0;
   };
   return bjornFams
-    .filter((bjornFam) => have(bjornFam.familiar))
-    .filter((bjornFam) => myFamiliar() !== bjornFam.familiar)
+    .filter((bjornFam) => have(bjornFam.familiar) && myFamiliar() !== bjornFam.familiar)
     .sort(
       (a, b) =>
         a.meatVal * a.probability() +

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,5 +1,6 @@
 import { canAdv } from "canadv.ash";
 import {
+  autosellPrice,
   buy,
   cliExecute,
   equip,
@@ -361,4 +362,181 @@ const freeRuns: freeRun[] = [
 
 export function findRun() {
   return freeRuns.find((run) => run.available());
+}
+function averageValue(items: Item[]) {
+  return items.map((item) => mallPrice(item)).reduce((x, price) => x + price, 0) / items.length;
+}
+interface famPick {
+  familiar: Familiar;
+  meatVal: number;
+  probability: () => number;
+}
+
+const bjornFams = [
+  {
+      familiar: $familiar`puck man`,
+      meatVal: mallPrice($item`yellow pixel`),
+      probability: () => (get("_yellowPixelDropsCrown") < 25 ? 0.25 : 0),
+  },
+  {
+      familiar: $familiar`grimstone golem`,
+      meatVal: mallPrice($item`grimstone mask`),
+      probability: () => (get("_grimstoneMaskDropsCrown") === 0 ? 0.5 : 0),
+  },
+  { familiar: $familiar`Knob Goblin Organ Grinder`, meatVal: 30, probability: () => 1 },
+  {
+      familiar: $familiar`garbage fire`,
+      meatVal: mallPrice($item`burning newspaper`),
+      probability: () => (get("_garbageFireDropsCrown") < 3 ? 0.5 : 0),
+  },
+  {
+      familiar: $familiar`machine elf`,
+      meatVal:
+         averagePrice($items`abstraction: thought, abstraction: action, abstraction: category, abstraction: perception, abstraction: purpose`),
+      probability: () => (get("_abstractionDropsCrown") < 25 ? 0.2 : 0),
+  },
+  {
+      familiar: $familiar`trick-or-treating tot`,
+      meatVal: mallPrice($item`hoarded candy wad`),
+      probability: () => (get("_hoardedCandyDropsCrown") < 3 ? 0.5 : 0),
+  },
+  {
+      familiar: $familiar`warbear drone`,
+      meatVal: mallPrice($item`warbear whosit`),
+      probability: () => 1 / 4.5,
+  },
+  {
+      familiar: $familiar`li'l xenomorph`,
+      meatVal: mallPrice($item`lunar isotope`),
+      probability: () => 0.05,
+  },
+  {
+      familiar: $familiar`pottery barn owl`,
+      meatVal: mallPrice($item`volcanic ash`),
+      probability: () => 0.1,
+  },
+  {
+    familiar: $familiar`grim brother`,
+    meatVal: mallPrice($item`grim fairy tale`),
+    probability: () => get("_grimFairyTaleDropsCrown") < 2 ? 1 : 0
+  },
+  {
+    familiar: $familiar`optimistic candle`,
+    meatVal: mallPrice($item`glob of melted wax`),
+    probability: () => get("_optimisticCandleDropsCrown") < 3 ? 1 : 0
+  },
+  {
+    familiar: $familiar`Adventurous Spelunker`,
+    meatVal: averagePrice($items`teflon ore, Velcro ore, Vinyl ore, cardboard ore, styrofoam ore, bubblewrap ore`),
+    probability: () => get("_oreDropsCrown") < 6 ? 1 : 0,
+  },
+  {
+    familiar: $familiar`Twitching Space Critter`,
+    meatVal: mallPrice($item`space beast fur`),
+    probability: () => get("_spaceFurDropsCrown") < 1 ? 1 : 0
+  },
+  {
+    familiar: $familiar`party mouse`,
+    meatVal: averagePrice(Item.all().filter((booze) => ["decent", "good"].includes(booze.quality) && booze.inebriety > 0 && booze.tradeable && booze.discardable && !$items`glass of "milk", cup of "tea", thermos of "whiskey", Lucky Lindy, Bee's Knees, Sockdollager, Ish Kabibble, Hot Socks, Phonus Balonus, Flivver, Sloppy Jalopy`.includes(booze))),
+    probability: () => 0.05
+  },
+  {
+    familiar: $familiar`yule hound`,
+    meatVal: mallPrice($item`candy cane`),
+    probability: () => 1
+  },
+  {
+    familiar: $familiar`gluttinous green ghost`,
+    meatVal: averagePrice($items`bean burrito, enchanted bean burrito, jumping bean burrito`),
+    probability: () => 1
+  },
+  {
+    familiar: $familiar`Reassembled Blackbird`,
+    meatVal: mallPrice($item`blackberry`),
+    probability: () => 1
+  },
+  {
+    familiar: $familiar`Hunchbacked Minion`,
+    meatVal: averagePrice($items`176,163,163,163,163`),
+    probability: () => 1
+  },
+  {
+    familiar: $familiar`reanimated reanimator`,
+    meatVal: averagePrice($items`hot wing,broken skull`),
+    probability: () => 1
+  },
+  {
+    familiar: $familiar`attention-deficit demon`,
+    meatVal: averagePrice($items`chorizo brownies,white chocolate and tomato pizza,carob chunk noodles`),
+    probability: () => 1
+  },
+  {
+    familiar: $familiar`piano cat`,
+    meatVal: averagePrice($items`beertini,papaya slung,salty slug,tomato daiquiri`),
+    probability: () => 1
+  },
+  {
+    familiar: $familiar`golden monkey`,
+    meatVal: 100,
+    probability: () => 0.5
+  },
+  {
+    familiar: $familiar`robot reindeer`,
+    meatVal: averageValue($items`candy cane,eggnog,fruitcake,gingerbread bugbear`),
+    probability: () => 0.3
+  },
+  {
+  familiar: $familiar`stocking mimic`,
+  meatVal: averageValue($items`540,617,906,908,909`),
+  probability: () => 0.3
+  },
+  {
+    familiar: $familiar`BRICKO chick`,
+    meatVal: autosellPrice($item`BRICKO brick`),
+    probability: () => 1
+  },
+  {
+    familiar: $familiar`Cotton Candy Carnie`,
+    meatVal: mallPrice($item`cotton candy pinch`),
+    probability: () => 1
+  },
+  {
+    familiar: $familiar`unnamed turtle`,
+    meatVal: averageValue($items`snailmail bits,turtlemail bits,turtle wax`),
+    probability: () => 0.35
+  },
+  {
+    familiar: $familiar`astral badger`,
+    meatVal: 2 * averageValue($items`spooky mushroom, knob mushroom, knoll mushroom`),
+    probability: () => 1
+  },
+{
+  familiar: $familiar`green pixie`,
+  meatVal: mallPrice($item`bottle of tequila`),
+  probability: () => 0.2
+},
+{
+  familiar: $familiar`angry goat`,
+  meatVal: mallPrice($item`goat cheese pizza`),
+  probability: () => 1
+},
+{
+  familiar: $familiar`adorable seal larva`,
+  meatVal: averageValue($items`1445,1446,1447,1448,1449`),
+  probability: () => 0.35
+},
+{
+  familiar: $familiar`ancient yuletide troll`,
+  meatVal: averageValue($items`candy cane,eggnog,fruitcake,gingerbread bugbear`),
+  probability: () => 0.3
+},
+{
+  familiar: $familiar`sweet nutcracker`,
+  meatVal: averageValue($items`candy cane,eggnog,fruitcake,gingerbread bugbear`),
+  probability: () => 0.3
+}
+];
+
+export function pickBjorn() {
+  return bjornFams.filter((bjornFam) => have(bjornFam.familiar)).sort((a, b) => a.meatVal * a.probability() - b.meatVal * b.probability())[0]
 }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -365,7 +365,7 @@ function trueValue(...items: Item[]) {
   return (
     items
       .map((item) => {
-        if (!item.discardable) {
+        if (item.discardable) {
           return mallPrice(item) > 2 * autosellPrice(item) ? mallPrice(item) : autosellPrice(item);
         }
         return mallPrice(item) > 100 ? mallPrice(item) : 0;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -298,7 +298,7 @@ const freeRuns: freeRun[] = [
     () => {
       if (getWorkshed() !== $item`Asdon Martin keyfob`) return false;
       const banishes = get("banishedMonsters").split(":");
-      const bumperIndex = banishes.indexOf("spring-loaded front bumper");
+      const bumperIndex = banishes.map((string) => string.toLowerCase()).indexOf("spring-loaded front bumper");
       if (bumperIndex === -1) return true;
       return myTurncount() - parseInt(banishes[bumperIndex + 1]) > 30;
     },

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -364,14 +364,16 @@ export function findRun() {
   return freeRuns.find((run) => run.available());
 }
 function trueValue(...items: Item[]) {
-  return items
-    .map((item) => {
-      if (!item.discardable) {
-        return mallPrice(item) > 2 * autosellPrice(item) ? mallPrice(item) : autosellPrice(item);
-      }
-      return mallPrice(item) > 100 ? mallPrice(item) : 0;
-    })
-    .reduce((s, price) => s + price, 0) / items.length;
+  return (
+    items
+      .map((item) => {
+        if (!item.discardable) {
+          return mallPrice(item) > 2 * autosellPrice(item) ? mallPrice(item) : autosellPrice(item);
+        }
+        return mallPrice(item) > 100 ? mallPrice(item) : 0;
+      })
+      .reduce((s, price) => s + price, 0) / items.length
+  );
 }
 interface famPick {
   familiar: Familiar;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -10,6 +10,7 @@ import {
   maximize,
   myFamiliar,
   myTurncount,
+  numericModifier,
   print,
   restoreMp,
   runChoice,
@@ -39,6 +40,7 @@ import {
   set,
 } from "libram";
 import { fillAsdonMartinTo } from "./asdon";
+import { meatFamiliar } from "./familiar";
 import { baseMeat } from "./mood";
 
 export function setChoice(adventure: number, value: number) {
@@ -784,8 +786,8 @@ const bjornFams: BjornedFamiliar[] = [
     probability: () => 1,
     modifier: {
       type: BjornModifierType.FMWT,
-      modifier: 5
-    }
+      modifier: 5,
+    },
   },
   {
     familiar: $familiar`Gelatinous Cubeling`,
@@ -793,9 +795,9 @@ const bjornFams: BjornedFamiliar[] = [
     probability: () => 0,
     modifier: {
       type: BjornModifierType.FMWT,
-      modifier: 5
-    }
-  }
+      modifier: 5,
+    },
+  },
 ];
 
 export enum PickBjornMode {
@@ -814,8 +816,16 @@ export function pickBjorn(mode: PickBjornMode = PickBjornMode.FREE) {
       return (familiar.modifier.modifier * meatVal) / 100;
     if (familiar.modifier.type === BjornModifierType.ITEM)
       return (familiar.modifier.modifier * itemVal) / 100;
-    if (familiar.modifier.type === BjornModifierType.FMWT)
-      return (familiar.modifier.modifier * meatVal * 2) / 100; //horrible hack, improve
+    if (familiar.modifier.type === BjornModifierType.FMWT) {
+      const lepMultiplier = numericModifier(meatFamiliar(), "Leprechaun", 1, Item.get("none"));
+      const fairyMultiplier = numericModifier(meatFamiliar(), "Fairy", 1, Item.get("none"));
+      return (
+        (meatVal * (10 * lepMultiplier + (75 * Math.sqrt(lepMultiplier)) / Math.sqrt(245)) +
+          itemVal *
+            (5 * fairyMultiplier + (5 * Math.sqrt(55 * fairyMultiplier)) / (2 * Math.sqrt(60)))) /
+        100
+      );
+    }
     return 0;
   };
   return bjornFams

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -793,17 +793,17 @@ export function pickBjorn(mode: PickBjornMode = PickBjornMode.FREE) {
       mode === PickBjornMode.FREE ? 0 : baseMeat + mode === PickBjornMode.EMBEZZLER ? 750 : 0;
     const itemVal = PickBjornMode.BARF ? 72 : 0;
     if (familiar.modifier.type === BjornModifierType.MEAT)
-      return familiar.modifier.modifier * meatVal;
+      return (familiar.modifier.modifier * meatVal) / 100;
     if (familiar.modifier.type === BjornModifierType.ITEM)
-      return familiar.modifier.modifier * itemVal;
+      return (familiar.modifier.modifier * itemVal) / 100;
     if (familiar.modifier.type === BjornModifierType.FMWT)
-      return familiar.modifier.modifier * meatVal * 2; //horrible hack, improve
+      return (familiar.modifier.modifier * meatVal * 2) / 100; //horrible hack, improve
     return 0;
   };
   return bjornFams
     .filter((bjornFam) => have(bjornFam.familiar) && myFamiliar() !== bjornFam.familiar)
     .sort(
-      (a, b) =>
+      (b, a) =>
         a.meatVal * a.probability() +
         additionalValue(a) -
         (b.meatVal * b.probability() + additionalValue(b))

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -23,7 +23,7 @@ import {
   maximizeCached,
   MaximizeOptions,
 } from "libram";
-import { pickBjorn } from "./lib";
+import { pickBjorn, PickBjornMode } from "./lib";
 import { baseMeat } from "./mood";
 
 export class Requirement {
@@ -64,7 +64,7 @@ export class Requirement {
 }
 
 export function freeFightOutfit(requirements: Requirement[] = []) {
-  const bjornChoice = pickBjorn();
+  const bjornChoice = pickBjorn(PickBjornMode.FREE);
   const compiledRequirements = Requirement.merge([
     ...requirements,
     new Requirement(
@@ -87,7 +87,7 @@ export function freeFightOutfit(requirements: Requirement[] = []) {
 export function meatOutfit(embezzlerUp: boolean, requirements: Requirement[] = [], sea?: boolean) {
   const forceEquip = [];
   const additionalRequirements = [];
-  const bjornChoice = pickBjorn();
+  const bjornChoice = pickBjorn(embezzlerUp ? PickBjornMode.EMBEZZLER : PickBjornMode.BARF);
   if (myInebriety() > inebrietyLimit()) {
     forceEquip.push($item`Drunkula's wineglass`);
   } else if (!embezzlerUp) {

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -9,6 +9,8 @@ import {
   totalTurnsPlayed,
   booleanModifier,
   cliExecute,
+  haveEquipped,
+  bjornifyFamiliar,
 } from "kolmafia";
 import {
   $class,
@@ -79,6 +81,7 @@ export function freeFightOutfit(requirements: Requirement[] = []) {
     ),
   ]);
   maximizeCached(compiledRequirements.maximizeParameters(), compiledRequirements.maximizeOptions());
+  if (haveEquipped($item`buddy bjorn`)) bjornifyFamiliar(bjornChoice.familiar);
 }
 
 export function meatOutfit(embezzlerUp: boolean, requirements: Requirement[] = [], sea?: boolean) {
@@ -142,6 +145,7 @@ export function meatOutfit(embezzlerUp: boolean, requirements: Requirement[] = [
   if (equippedAmount($item`ice nine`) > 0) {
     equip($item`unwrapped retro superhero cape`);
   }
+  if (haveEquipped($item`buddy bjorn`)) bjornifyFamiliar(bjornChoice.familiar);
   if (sea) {
     if (!booleanModifier("Adventure Underwater")) {
       for (let airSource of waterBreathingEquipment) {

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -21,6 +21,7 @@ import {
   maximizeCached,
   MaximizeOptions,
 } from "libram";
+import { pickBjorn } from "./lib";
 import { baseMeat } from "./mood";
 
 export class Requirement {
@@ -61,6 +62,7 @@ export class Requirement {
 }
 
 export function freeFightOutfit(requirements: Requirement[] = []) {
+  const bjornChoice = pickBjorn();
   const compiledRequirements = Requirement.merge([
     ...requirements,
     new Requirement(
@@ -71,6 +73,7 @@ export function freeFightOutfit(requirements: Requirement[] = []) {
           [$item`Mr. Cheeng's spectacles`, 250],
           [$item`pantogram pants`, 100],
           [$item`Mr. Screege's spectacles`, 180],
+          [$item`buddy bjorn`, bjornChoice.meatVal * bjornChoice.probability()]
         ]),
       }
     ),
@@ -81,6 +84,7 @@ export function freeFightOutfit(requirements: Requirement[] = []) {
 export function meatOutfit(embezzlerUp: boolean, requirements: Requirement[] = [], sea?: boolean) {
   const forceEquip = [];
   const additionalRequirements = [];
+  const bjornChoice = pickBjorn();
   if (myInebriety() > inebrietyLimit()) {
     forceEquip.push($item`Drunkula's wineglass`);
   } else if (!embezzlerUp) {
@@ -129,6 +133,7 @@ export function meatOutfit(embezzlerUp: boolean, requirements: Requirement[] = [
           [$item`Mr. Cheeng's spectacles`, 250],
           [$item`pantogram pants`, 100],
           [$item`Mr. Screege's spectacles`, 180],
+          [$item`buddy bjorn`, bjornChoice.meatVal * bjornChoice.probability()]
         ]),
       }
     ),

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -73,7 +73,7 @@ export function freeFightOutfit(requirements: Requirement[] = []) {
           [$item`Mr. Cheeng's spectacles`, 250],
           [$item`pantogram pants`, 100],
           [$item`Mr. Screege's spectacles`, 180],
-          [$item`buddy bjorn`, bjornChoice.meatVal * bjornChoice.probability()]
+          [$item`buddy bjorn`, bjornChoice.meatVal * bjornChoice.probability()],
         ]),
       }
     ),
@@ -133,7 +133,7 @@ export function meatOutfit(embezzlerUp: boolean, requirements: Requirement[] = [
           [$item`Mr. Cheeng's spectacles`, 250],
           [$item`pantogram pants`, 100],
           [$item`Mr. Screege's spectacles`, 180],
-          [$item`buddy bjorn`, bjornChoice.meatVal * bjornChoice.probability()]
+          [$item`buddy bjorn`, bjornChoice.meatVal * bjornChoice.probability()],
         ]),
       }
     ),

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -11,6 +11,7 @@ import {
   cliExecute,
   haveEquipped,
   bjornifyFamiliar,
+  enthroneFamiliar,
 } from "kolmafia";
 import {
   $class,
@@ -65,6 +66,7 @@ export class Requirement {
 
 export function freeFightOutfit(requirements: Requirement[] = []) {
   const bjornChoice = pickBjorn(PickBjornMode.FREE);
+  const bjornAlike = have($item`buddy bjorn`) ? $item`buddy bjorn` : $item`crown of thrones`;
   const compiledRequirements = Requirement.merge([
     ...requirements,
     new Requirement(
@@ -75,19 +77,21 @@ export function freeFightOutfit(requirements: Requirement[] = []) {
           [$item`Mr. Cheeng's spectacles`, 250],
           [$item`pantogram pants`, 100],
           [$item`Mr. Screege's spectacles`, 180],
-          [$item`buddy bjorn`, bjornChoice.meatVal * bjornChoice.probability()],
+          [bjornAlike, bjornChoice.meatVal * bjornChoice.probability()],
         ]),
       }
     ),
   ]);
   maximizeCached(compiledRequirements.maximizeParameters(), compiledRequirements.maximizeOptions());
   if (haveEquipped($item`buddy bjorn`)) bjornifyFamiliar(bjornChoice.familiar);
+  if (haveEquipped($item`crown of thrones`)) enthroneFamiliar(bjornChoice.familiar);
 }
 
 export function meatOutfit(embezzlerUp: boolean, requirements: Requirement[] = [], sea?: boolean) {
   const forceEquip = [];
   const additionalRequirements = [];
   const bjornChoice = pickBjorn(embezzlerUp ? PickBjornMode.EMBEZZLER : PickBjornMode.BARF);
+  const bjornAlike = have($item`buddy bjorn`) ? $item`buddy bjorn` : $item`crown of thrones`;
   if (myInebriety() > inebrietyLimit()) {
     forceEquip.push($item`Drunkula's wineglass`);
   } else if (!embezzlerUp) {
@@ -136,7 +140,7 @@ export function meatOutfit(embezzlerUp: boolean, requirements: Requirement[] = [
           [$item`Mr. Cheeng's spectacles`, 250],
           [$item`pantogram pants`, 100],
           [$item`Mr. Screege's spectacles`, 180],
-          [$item`buddy bjorn`, bjornChoice.meatVal * bjornChoice.probability()],
+          [bjornAlike, bjornChoice.meatVal * bjornChoice.probability()],
         ]),
       }
     ),
@@ -146,6 +150,7 @@ export function meatOutfit(embezzlerUp: boolean, requirements: Requirement[] = [
     equip($item`unwrapped retro superhero cape`);
   }
   if (haveEquipped($item`buddy bjorn`)) bjornifyFamiliar(bjornChoice.familiar);
+  if (haveEquipped($item`crown of thrones`)) enthroneFamiliar(bjornChoice.familiar);
   if (sea) {
     if (!booleanModifier("Adventure Underwater")) {
       for (let airSource of waterBreathingEquipment) {


### PR DESCRIPTION
Currently approximates value of familiar weight using a linearization based on your meat familiar's leprechaun multiplier.

May overvalue bjorn/crown in the maximizer (it gives a bonus on top of its regular score), but bjorn is pretty much always worth wielding anyways.

Bjorn-familiar list is not exhaustive, but covers most bases.