### PR TITLE
ignore familiars that drop items when picking your embezzler bjorn choice

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -875,9 +875,13 @@ function generateBjornList(mode: PickBjornMode): BjornedFamiliar[] {
   };
   return [...bjornFams].sort(
     (a, b) =>
-      (!b.dropPredicate || b.dropPredicate() ? b.meatVal() * b.probability : 0) +
+      (mode !== PickBjornMode.EMBEZZLER && (!b.dropPredicate || b.dropPredicate())
+        ? b.meatVal() * b.probability
+        : 0) +
       additionalValue(b) -
-      ((!a.dropPredicate || a.dropPredicate() ? a.meatVal() * a.probability : 0) +
+      ((mode !== PickBjornMode.EMBEZZLER && (!a.dropPredicate || a.dropPredicate())
+        ? a.meatVal() * a.probability
+        : 0) +
         additionalValue(a))
   );
 }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -875,11 +875,11 @@ function generateBjornList(mode: PickBjornMode): BjornedFamiliar[] {
   };
   return [...bjornFams].sort(
     (a, b) =>
-      (mode !== PickBjornMode.EMBEZZLER && (!b.dropPredicate || b.dropPredicate())
+      (!b.dropPredicate || (b.dropPredicate() && mode !== PickBjornMode.EMBEZZLER)
         ? b.meatVal() * b.probability
         : 0) +
       additionalValue(b) -
-      ((mode !== PickBjornMode.EMBEZZLER && (!a.dropPredicate || a.dropPredicate())
+      ((!a.dropPredicate || (a.dropPredicate() && mode !== PickBjornMode.EMBEZZLER)
         ? a.meatVal() * a.probability
         : 0) +
         additionalValue(a))


### PR DESCRIPTION
You'll get those drops eventually, and so it is better to use familiars that give +meat% on embezzlers and get those items from free fights or regular barf monsters