### PR TITLE
pantsgiving support

### DIFF
--- a/src/combat.ts
+++ b/src/combat.ts
@@ -96,6 +96,7 @@ export class Macro extends LibramMacro {
       .externalIf(opsSetup, Macro.skill("Throw Shield").attack())
       .externalIf(katanaSetup, Macro.skill("Summer Siesta").attack())
       .externalIf(capeSetup, Macro.skill("Precision Shot"))
+      .trySkill("Pocket Crumbs")
       .if_(
         "discobandit",
         Macro.trySkill("Disco Dance of Doom")

--- a/src/dailies.ts
+++ b/src/dailies.ts
@@ -45,6 +45,7 @@ import {
 } from "libram";
 import { songBoomSongs } from "libram/dist/resources/2018/SongBoom";
 import { globalOptions } from ".";
+import { horseradish } from "./diet";
 import { meatFamiliar } from "./familiar";
 import { questStep, ensureEffect, tryFeast, findRun, trueValue, withProperties } from "./lib";
 import { baseMeat } from "./mood";
@@ -147,6 +148,7 @@ export function latte() {
               runSource.prepare();
               equip($slot`off-hand`, latte);
               adventureMacro($location`the black forest`, runSource.macro);
+              horseradish();
             }
           }
         );
@@ -164,6 +166,7 @@ export function latte() {
               runSource.prepare();
               equip($slot`off-hand`, latte);
               adventureMacro($location`the spooky forest`, runSource.macro);
+              horseradish();
             }
           }
         );
@@ -175,6 +178,7 @@ export function latte() {
           runSource.prepare();
           equip($slot`off-hand`, latte);
           adventureMacro($location`the dire warren`, runSource.macro);
+          horseradish();
         }
       }
       if (

--- a/src/diet.ts
+++ b/src/diet.ts
@@ -363,3 +363,11 @@ export function runDiet(): void {
     drinkSafe(1, $item`ambitious turkey`);
   }
 }
+
+export function horseradish() {
+  if (myFullness() < fullnessLimit()) {
+    if (mallPrice($item`fudge spork`) < 3 * MPA && !get("_fudgeSporkUsed"))
+      eat(1, $item`fudge spork`);
+    eatSafe(1, $item`jumping horseradish`);
+  }
+}

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -72,6 +72,7 @@ import {
 } from "libram";
 import { fillAsdonMartinTo } from "./asdon";
 import { Macro, withMacro } from "./combat";
+import { horseradish } from "./diet";
 import { freeFightFamiliar, meatFamiliar } from "./familiar";
 import {
   clamp,
@@ -526,7 +527,7 @@ class FreeFight {
       freeFightOutfit(this.options.requirements ? this.options.requirements() : []);
       safeRestore();
       withMacro(Macro.meatKill(), this.run);
-
+      horseradish();
       // Slot in our Professor Thesis if it's become available
       if (thesisReady()) deliverThesis();
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ import {
   volcanoDailies,
   voterSetup,
 } from "./dailies";
-import { runDiet } from "./diet";
+import { horseradish, runDiet } from "./diet";
 import { freeFightFamiliar, meatFamiliar } from "./familiar";
 import { dailyFights, freeFights, safeRestore } from "./fights";
 import { questStep, prepWandererZone, physicalImmuneMacro, withProperties } from "./lib";
@@ -139,6 +139,7 @@ function barfTurn() {
     retrieveItem($item`pulled green taffy`);
     if (!have($effect`Fishy`)) use($item`fishy pipe`);
     location = $location`The Briny Deeps`;
+    horseradish();
   }
 
   const underwater = location === $location`The Briny Deeps`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,7 @@ function dailySetup() {
 }
 
 function barfTurn() {
+  horseradish();
   if (have($effect`beaten up`))
     throw "Hey, you're beaten up, and that's a bad thing. Lick your wounds, handle your problems, and run me again when you feel ready.";
   if (SourceTerminal.have()) {
@@ -139,7 +140,6 @@ function barfTurn() {
     retrieveItem($item`pulled green taffy`);
     if (!have($effect`Fishy`)) use($item`fishy pipe`);
     location = $location`The Briny Deeps`;
-    horseradish();
   }
 
   const underwater = location === $location`The Briny Deeps`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -306,7 +306,7 @@ export function main(argString = "") {
         ) {
           visitUrl("guild.php?action=buyskill&skillid=32", true);
         }
-        const stashItems = $items`repaid diaper, buddy bjorn, crown of thrones, origami pasties`;
+        const stashItems = $items`repaid diaper, buddy bjorn, crown of thrones, origami pasties, pantsgiving`;
         if (
           myInebriety() <= inebrietyLimit() &&
           (myClass() !== $class`seal clubber` || !have($skill`furious wallop`))

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -227,5 +227,5 @@ function pantsgivingBonus() {
     sinusVal +
     get("valueOfAdventure") * 6.5 -
     (mallPrice($item`jumping horseradish`) + mallPrice($item`special seasoning`));
-  return fullnessValue / turns;
+  return fullnessValue / (turns - 5 * Math.pow(10, Math.floor(Math.log10(count / 5))));
 }

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -15,6 +15,8 @@ import {
   toSlot,
   myAdventures,
   mallPrice,
+  fullnessLimit,
+  myFullness,
 } from "kolmafia";
 import {
   $class,
@@ -220,7 +222,12 @@ export const familiarWaterBreathingEquipment = $items`das boot, little bitty bat
 function pantsgivingBonus() {
   if (!have($item`pantsgiving`)) return 0;
   const count = get("_pantsgivingCount");
-  const turns = [5, 50, 500, 5000].find((x) => count < x) || 50000;
+  const turnArray = [5, 50, 500, 5000];
+  const index =
+    myFullness() === fullnessLimit()
+      ? get("_pantsgivingFullness")
+      : turnArray.findIndex((x) => count < x);
+  const turns = turnArray[index] || 50000;
   if (turns - count > myAdventures() * 1.04) return 0;
   const sinusVal = 50 * 1.0 * baseMeat; //if we add mayozapine support, fiddle with this
   const fullnessValue =

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -222,8 +222,9 @@ function pantsgivingBonus() {
   const count = get("_pantsgivingCount");
   const turns = 5 * Math.pow(10, Math.ceil(Math.log10(count / 5)));
   if (turns - count > myAdventures() * 1.04) return 0;
+  const sinusVal = 50 * 1.0 * baseMeat; //if we add mayozapine support, fiddle with this
   const fullnessValue =
-    50 * 1.0 * baseMeat +
+    sinusVal +
     get("valueOfAdventure") * 6.5 -
     (mallPrice($item`jumping horseradish`) + mallPrice($item`special seasoning`));
   return fullnessValue / turns;

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -220,12 +220,12 @@ export const familiarWaterBreathingEquipment = $items`das boot, little bitty bat
 function pantsgivingBonus() {
   if (!have($item`pantsgiving`)) return 0;
   const count = get("_pantsgivingCount");
-  const turns = 5 * Math.pow(10, Math.ceil(Math.log10(count / 5)));
+  const turns = 5 * Math.pow(10, Math.ceil(Math.max(0, Math.log10(Math.max(1, count / 5)))));
   if (turns - count > myAdventures() * 1.04) return 0;
   const sinusVal = 50 * 1.0 * baseMeat; //if we add mayozapine support, fiddle with this
   const fullnessValue =
     sinusVal +
     get("valueOfAdventure") * 6.5 -
     (mallPrice($item`jumping horseradish`) + mallPrice($item`special seasoning`));
-  return fullnessValue / (turns - 5 * Math.pow(10, Math.floor(Math.log10(count / 5))));
+  return fullnessValue / (turns * 0.9);
 }

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -176,7 +176,7 @@ export function meatOutfit(embezzlerUp: boolean, requirements: Requirement[] = [
           [$item`Mr. Cheeng's spectacles`, 250],
           [$item`pantogram pants`, 100],
           [$item`Mr. Screege's spectacles`, 180],
-          [$item`pantsgiving`, pantsgivingBonus()],
+          [$item`pantsgiving`, embezzlerUp ? 0 : pantsgivingBonus()],
           [
             bjornAlike,
             !bjornChoice.dropPredicate || bjornChoice.dropPredicate()

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -220,7 +220,7 @@ export const familiarWaterBreathingEquipment = $items`das boot, little bitty bat
 function pantsgivingBonus() {
   if (!have($item`pantsgiving`)) return 0;
   const count = get("_pantsgivingCount");
-  const turns = 5 * Math.pow(10, Math.ceil(Math.max(0, Math.log10(Math.max(1, count / 5)))));
+  const turns = [5, 50, 500, 5000].find((x) => count < x) || 50000;
   if (turns - count > myAdventures() * 1.04) return 0;
   const sinusVal = 50 * 1.0 * baseMeat; //if we add mayozapine support, fiddle with this
   const fullnessValue =

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -13,6 +13,8 @@ import {
   bjornifyFamiliar,
   enthroneFamiliar,
   toSlot,
+  myAdventures,
+  mallPrice,
 } from "kolmafia";
 import {
   $class,
@@ -79,6 +81,7 @@ export function freeFightOutfit(requirements: Requirement[] = []) {
           [$item`Mr. Cheeng's spectacles`, 250],
           [$item`pantogram pants`, 100],
           [$item`Mr. Screege's spectacles`, 180],
+          [$item`pantsgiving`, pantsgivingBonus()],
         ]),
       }
     ),
@@ -171,6 +174,7 @@ export function meatOutfit(embezzlerUp: boolean, requirements: Requirement[] = [
           [$item`Mr. Cheeng's spectacles`, 250],
           [$item`pantogram pants`, 100],
           [$item`Mr. Screege's spectacles`, 180],
+          [$item`pantsgiving`, pantsgivingBonus()],
           [
             bjornAlike,
             !bjornChoice.dropPredicate || bjornChoice.dropPredicate()
@@ -212,3 +216,15 @@ export function meatOutfit(embezzlerUp: boolean, requirements: Requirement[] = [
 
 export const waterBreathingEquipment = $items`The Crown of Ed the Undying, aerated diving helmet, crappy mer-kin mask, Mer-kin gladiator mask, Mer-kin scholar mask, old SCUBA tank`;
 export const familiarWaterBreathingEquipment = $items`das boot, little bitty bathysphere`;
+
+function pantsgivingBonus() {
+  if (!have($item`pantsgiving`)) return 0;
+  const count = get("_pantsgivingCount");
+  const turns = 5 * Math.pow(10, Math.ceil(Math.log10(count / 5)));
+  if (turns - count > myAdventures() * 1.04) return 0;
+  const fullnessValue =
+    50 * 1.0 * baseMeat +
+    get("valueOfAdventure") * 6.5 -
+    (mallPrice($item`jumping horseradish`) + mallPrice($item`special seasoning`));
+  return fullnessValue / turns;
+}


### PR DESCRIPTION
Calculate value of pantsgiving assuming horseradish with seasoning and sans-mayozapine; verify we have enough turns to get an extra fullness, and add as a bonus equip.

Add a horseradish() function after just about every fight I can find. There must be a better way to do that, though.

Resolves #77 