### PR TITLE
add mayo support

### DIFF
--- a/src/diet.ts
+++ b/src/diet.ts
@@ -33,8 +33,11 @@ import {
   userConfirm,
   myFamiliar,
   useFamiliar,
+  getWorkshed,
+  retrieveItem,
 } from "kolmafia";
 import { $class, $effect, $item, $items, $skill, get, have, $familiar, set } from "libram";
+import { withChoice } from "libram/dist/property";
 import { globalOptions } from ".";
 import { clamp, ensureEffect } from "./lib";
 
@@ -230,6 +233,7 @@ function fillStomach() {
     if (myMaxhp() < 1000) maximize("0.05hp, hot res", false);
     const count = Math.floor(Math.min((fullnessLimit() - myFullness()) / 5, mySpleenUse() / 5));
     eatSpleen(count, $item`Ol' Scratch's salad fork`);
+    mindMayo(Mayo.flex, count);
     eatSpleen(count, $item`extra-greasy slider`);
     fillSomeSpleen();
   }
@@ -373,6 +377,24 @@ export function horseradish() {
   if (myFullness() < fullnessLimit()) {
     if (mallPrice($item`fudge spork`) < 3 * MPA && !get("_fudgeSporkUsed"))
       eat(1, $item`fudge spork`);
+    mindMayo(Mayo.zapine, 1);
     eatSafe(1, $item`jumping horseradish`);
+  }
+}
+
+const Mayo = {
+  nex: $item`Mayonex`,
+  diol: $item`Mayodiol`,
+  zapine: $item`Mayozapine`,
+  flex: $item`Mayoflex`,
+};
+
+function mindMayo(mayo: Item, quantity: number) {
+  if (getWorkshed() !== $item`Portable Mayo Clinic`) return;
+  if (get("mayoInMouth") !== mayo.name) throw `You used a bad mayo, my friend!`; //Is this what we want?
+  retrieveItem(quantity, mayo);
+  if (!have($item`Mayo Minder`)) buy($item`Mayo Minder`);
+  if (get("mayoMinderSetting") !== mayo.name) {
+    withChoice(1076, toInt(mayo) - 8260, () => use($item`mayo minder`));
   }
 }

--- a/src/diet.ts
+++ b/src/diet.ts
@@ -391,7 +391,8 @@ const Mayo = {
 
 function mindMayo(mayo: Item, quantity: number) {
   if (getWorkshed() !== $item`Portable Mayo Clinic`) return;
-  if (get("mayoInMouth") !== mayo.name) throw `You used a bad mayo, my friend!`; //Is this what we want?
+  if (get("mayoInMouth") && get("mayoInMouth") !== mayo.name)
+    throw `You used a bad mayo, my friend!`; //Is this what we want?
   retrieveItem(quantity, mayo);
   if (!have($item`Mayo Minder`)) buy($item`Mayo Minder`);
   if (get("mayoMinderSetting") !== mayo.name) {

--- a/src/diet.ts
+++ b/src/diet.ts
@@ -366,6 +366,7 @@ export function runDiet(): void {
   while (myFullness() < fullnessLimit()) {
     if (mallPrice($item`fudge spork`) < 3 * MPA && !get("_fudgeSporkUsed"))
       eat(1, $item`fudge spork`);
+    mindMayo(Mayo.zapine, 1);
     eatSafe(1, $item`jumping horseradish`);
   }
   while (myInebriety() < inebrietyLimit()) {


### PR DESCRIPTION
There are two potentially controversial choices that this script makes:

1. It aborts if you have an incorrect mayo in your mouth. Mayodiol is the big threat here, but Mayonex can also be bad.
2. It exclusively uses the Mayo Minder. This is because I'm concerned about accidentally filling your mouth with a mayo and then not wanting to use that mayo.

Resolves  #219