### PR TITLE
Add skeleton store and overgrown lot to blacklist

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -200,7 +200,7 @@ function guzzlrCheck() {
       use(1, place.potion);
     }
   });
-  const blacklist = $locations`The Oasis, The Bubblin' Caldera, Barrrney's Barrr, The F'c'le, The Poop Deck, Belowdecks, 8-Bit Realm, The Batrat and Ratbat Burrow, Guano Junction, The Beanbat Chamber, Madness Bakery, The Secret Government Laboratory`;
+  const blacklist = $locations`The Oasis, The Bubblin' Caldera, Barrrney's Barrr, The F'c'le, The Poop Deck, Belowdecks, 8-Bit Realm, The Batrat and Ratbat Burrow, Guano Junction, The Beanbat Chamber, Madness Bakery, The Secret Government Laboratory, The Overgrown Lot, The Skeleton Store`;
   if (
     forbiddenZones.includes(guzzlZone.zone) ||
     blacklist.includes(guzzlZone) ||


### PR DESCRIPTION
This is a temporary measure, until we come up with a system for deciding between digitized monsters and backups