### PR TITLE
add parantheses to the meatVal part of generateBjornList

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -884,7 +884,7 @@ function generateBjornList(mode: PickBjornMode): BjornedFamiliar[] {
   const additionalValue = (familiar: BjornedFamiliar) => {
     if (!familiar.modifier) return 0;
     const meatVal =
-      mode === PickBjornMode.FREE ? 0 : baseMeat + mode === PickBjornMode.EMBEZZLER ? 750 : 0;
+      mode === PickBjornMode.FREE ? 0 : baseMeat + (mode === PickBjornMode.EMBEZZLER ? 750 : 0);
     const itemVal = mode === PickBjornMode.BARF ? 72 : 0;
     if (familiar.modifier.type === BjornModifierType.MEAT)
       return (familiar.modifier.modifier * meatVal) / 100;


### PR DESCRIPTION
Despite what it may seem, this _did_ change the behavior of pickBjorn() for me, and it changed it for the better.

PickBjornModes are numbers, so previously this was being parsed as
`mode === PickBjornMode.FREE ? 0 : (baseMeat + mode) === PickBjornMode.EMBEZZLER ? 750 : 0`, which always returns 0. Or somethign else weird was happening, but adding these parantheses changed the behavior. 