### PR TITLE
replace getWorkshed with getCampground as it appears in horseradish()

### DIFF
--- a/src/diet.ts
+++ b/src/diet.ts
@@ -7,8 +7,8 @@ import {
   eat,
   equip,
   fullnessLimit,
+  getCampground,
   getProperty,
-  getWorkshed,
   haveEffect,
   inebrietyLimit,
   itemAmount,
@@ -328,7 +328,7 @@ const Mayo = {
 };
 
 function mindMayo(mayo: Item, quantity: number) {
-  if (getWorkshed() !== $item`portable Mayo Clinic`) return;
+  if (!getCampground()["portable Mayo Clinic"]) return;
   if (get("mayoInMouth") && get("mayoInMouth") !== mayo.name)
     throw `You used a bad mayo, my friend!`; //Is this what we want?
   retrieveItem(quantity, mayo);


### PR DESCRIPTION
Right now, mafia will have a VERY bad time if you use getWorkshed and have no workshed item. I'd like to return to getWorkshed in the long run, but until it's fixed, I'd like garbo to work.