### PR TITLE
Don't wasted final monster replace when extracting jelly

### DIFF
--- a/src/dailies.ts
+++ b/src/dailies.ts
@@ -486,7 +486,9 @@ export function jellyfish(): void {
     const jellyMacro = Macro.while_(
       "!pastround 28 && hasskill macrometeorite",
       Macro.skill("extract jelly").skill("macrometeorite")
-    ).step(runSource.macro);
+    )
+      .trySkill("extract jelly")
+      .step(runSource.macro);
     adventureMacro($location`Barf Mountain`, jellyMacro);
   }
   if (have($item`Powerful Glove`)) {
@@ -501,7 +503,9 @@ export function jellyfish(): void {
       const jellyMacro = Macro.while_(
         "!pastround 28 && hasskill CHEAT CODE: Replace Enemy",
         Macro.skill("extract jelly").skill("CHEAT CODE: Replace Enemy")
-      ).step(runSource.macro);
+      )
+        .trySkill("extract jelly")
+        .step(runSource.macro);
       adventureMacro($location`Barf Mountain`, jellyMacro);
     }
   }


### PR DESCRIPTION
Cast extract jelly one more time after using macrometeorite or replace monster, before running away. Currently the last monster replace is wasted.