### PR TITLE
Set preventSlot crown-of-thrones & buddy-bjorn when maximizing

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -254,6 +254,8 @@ export class Requirement {
       ]),
       forceEquip: [...(optionsA.forceEquip ?? []), ...(optionsB.forceEquip ?? [])],
       preventEquip: [...(optionsA.preventEquip ?? []), ...(optionsB.preventEquip ?? [])],
+      onlySlot: [...(optionsA.onlySlot ?? []), ...(optionsB.onlySlot ?? [])],
+      preventSlot: [...(optionsA.preventSlot ?? []), ...(optionsB.preventSlot ?? [])],
     });
   }
 

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -24,6 +24,7 @@ import {
   $item,
   $items,
   $slot,
+  $slots,
   get,
   getFoldGroup,
   getKramcoWandererChance,
@@ -87,6 +88,7 @@ export function freeFightOutfit(requirements: Requirement[] = []): void {
       ]),
       preventEquip:
         bjornAlike === $item`Buddy Bjorn` ? $items`Crown of Thrones` : $items`Buddy Bjorn`,
+      preventSlot: $slots`crown-of-thrones, buddy-bjorn`,
     })
   );
 
@@ -170,6 +172,7 @@ export function meatOutfit(
               : 0,
           ],
         ]),
+        preventSlot: $slots`crown-of-thrones, buddy-bjorn`,
       }
     ),
   ]);


### PR DESCRIPTION
This will prevent swapping enthroned\bjorned familiars over and over after a maximize cache is hit when garbo is manually setting the familiars for drops.

This needs an updated libram