### PR TITLE
Combat improvements

### DIFF
--- a/src/combat.ts
+++ b/src/combat.ts
@@ -202,7 +202,11 @@ export class Macro extends LibramMacro {
           Macro.while_("!pastround 3 && !hppercentbelow 25", Macro.item("seal tooth"))
         )
         .externalIf(
-          myFamiliar() === $familiar`Stocking Mimic`,
+          [
+            $familiar`Cocoabo`,
+            $familiar`Ninja Pirate Zombie Robot`,
+            $familiar`Stocking Mimic`,
+          ].some((familiar) => myFamiliar() === familiar),
           Macro.while_("!pastround 10 && !hppercentbelow 25", Macro.item("seal tooth"))
         )
         .externalIf(
@@ -231,7 +235,11 @@ export class Macro extends LibramMacro {
           Macro.while_(`!pastround 3 && monsterhpabove ${passiveDamage}`, Macro.item("seal tooth"))
         )
         .externalIf(
-          myFamiliar() === $familiar`Stocking Mimic`,
+          [
+            $familiar`Cocoabo`,
+            $familiar`Ninja Pirate Zombie Robot`,
+            $familiar`Stocking Mimic`,
+          ].some((familiar) => myFamiliar() === familiar),
           Macro.while_(`!pastround 10 && monsterhpabove ${passiveDamage}`, Macro.item("seal tooth"))
         )
         .externalIf(
@@ -267,7 +275,9 @@ export class Macro extends LibramMacro {
         Macro.while_("!pastround 3 && !hppercentbelow 25", Macro.item("seal tooth"))
       )
       .externalIf(
-        myFamiliar() === $familiar`Stocking Mimic`,
+        [$familiar`Cocoabo`, $familiar`Ninja Pirate Zombie Robot`, $familiar`Stocking Mimic`].some(
+          (familiar) => myFamiliar() === familiar
+        ),
         Macro.while_("!pastround 10 && !hppercentbelow 25", Macro.item("seal tooth"))
       )
       .externalIf(

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -145,20 +145,25 @@ export class Macro extends LibramMacro {
     )
       .tryHaveSkill($skill`Sing Along`)
       .externalIf(
-        !have($effect`On the Trail`),
+        !have($effect`On the Trail`) && have($skill`Transcendent Olfaction`),
         Macro.if_("monstername garbage tourist", Macro.trySkill("Transcendent Olfaction"))
       )
       .externalIf(
-        get("_gallapagosMonster") !== $monster`garbage tourist`,
+        get("_gallapagosMonster") !== $monster`garbage tourist` &&
+          have($skill`Gallapagosian Mating Call`),
         Macro.if_("monstername garbage tourist", Macro.trySkill("Gallapagosian Mating Call"))
       )
       .externalIf(
-        get("_latteMonster") !== $monster`garbage tourist` ||
-          getCounters("Latte Monster", 0, 30).trim() === "",
+        !get("_latteCopyUsed") &&
+          (get("_latteMonster") !== $monster`garbage tourist` ||
+            getCounters("Latte Monster", 0, 30).trim() === "") &&
+          have($item`latte lovers member's mug`),
         Macro.if_("monstername garbage tourist", Macro.trySkill("Offer Latte to Opponent"))
       )
       .externalIf(
-        get("lastCopyableMonster") === $monster`garbage tourist`,
+        get("_feelNostalgicUsed") < 3 &&
+          get("lastCopyableMonster") === $monster`garbage tourist` &&
+          have($skill`Feel Nostalgic`),
         Macro.if_("!monstername garbage tourist", Macro.trySkill("Feel Nostalgic"))
       )
       .meatStasis(willCrit)

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -51,14 +51,22 @@ export class Macro extends LibramMacro {
     return super.submit();
   }
 
-  tryHaveSkill(skillOrName: Skill | null): Macro {
-    if (!skillOrName) return this;
-    const skill = typeof skillOrName === "string" ? Skill.get(skillOrName) : skillOrName;
-    return this.externalIf(haveSkill(skill), Macro.skill(skill));
+  tryHaveSkill(skill: Skill | null): Macro {
+    if (!skill) return this;
+    return this.externalIf(haveSkill(skill), Macro.trySkill(skill));
   }
 
-  static tryHaveSkill(skillOrName: Skill | null): Macro {
-    return new Macro().tryHaveSkill(skillOrName);
+  static tryHaveSkill(skill: Skill | null): Macro {
+    return new Macro().tryHaveSkill(skill);
+  }
+
+  tryHaveItem(item: Item | null): Macro {
+    if (!item) return this;
+    return this.externalIf(have(item), Macro.tryItem(item));
+  }
+
+  static tryHaveItem(item: Item | null): Macro {
+    return new Macro().tryHaveItem(item);
   }
 
   tryCopier(itemOrSkill: Item | Skill): Macro {
@@ -233,7 +241,10 @@ export class Macro extends LibramMacro {
             Macro.item("seal tooth")
           )
         )
-        .if_(`monsterhpabove ${passiveDamage + 40}`, Macro.tryItem($item`porquoise-handled sixgun`))
+        .if_(
+          `monsterhpabove ${passiveDamage + 40}`,
+          Macro.tryHaveItem($item`porquoise-handled sixgun`)
+        )
     );
   }
 
@@ -246,11 +257,11 @@ export class Macro extends LibramMacro {
       .tryHaveSkill($skill`Curse of Weaksauce`)
       .trySkill($skill`Pocket Crumbs`)
       .trySkill($skill`Extract`)
-      .tryItem($item`porquoise-handled sixgun`)
-      .trySkill($skill`Micrometeorite`)
-      .tryItem($item`Time-Spinner`)
-      .tryItem($item`Rain-Doh indigo cup`)
-      .tryItem($item`Rain-Doh blue balls`)
+      .tryHaveItem($item`porquoise-handled sixgun`)
+      .externalIf(have($skill`Meteor Lore`), Macro.trySkill($skill`Micrometeorite`))
+      .tryHaveItem($item`Time-Spinner`)
+      .tryHaveItem($item`Rain-Doh indigo cup`)
+      .tryHaveItem($item`Rain-Doh blue balls`)
       .externalIf(
         haveEquipped($item`Buddy Bjorn`) || haveEquipped($item`Crown of Thrones`),
         Macro.while_("!pastround 3 && !hppercentbelow 25", Macro.item("seal tooth"))
@@ -367,7 +378,7 @@ export class Macro extends LibramMacro {
     }
 
     return this.tryHaveSkill($skill`Sing Along`)
-      .tryItem($item`Rain-Doh blue balls`)
+      .tryHaveItem($item`Rain-Doh blue balls`)
       .externalIf(get("lovebugsUnlocked"), Macro.trySkill($skill`Summon Love Gnats`))
       .tryHaveSkill(classStun)
       .tryHaveSkill(extraStun)

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -286,11 +286,11 @@ export class Macro extends LibramMacro {
   kill(): Macro {
     return (
       this.externalIf(
-        myClass() === $class`Sauceror`,
-        Macro.tryHaveSkill($skill`Curse of Weaksauce`)
+        myClass() === $class`Sauceror` && have($skill`Curse of Weaksauce`),
+        Macro.trySkill($skill`Curse of Weaksauce`)
       )
         .externalIf(
-          myClass() !== $class`Sauceror`,
+          !(myClass() === $class`Sauceror` && have($skill`Curse of Weaksauce`)),
           Macro.while_("!pastround 20 && !hppercentbelow 25 && !missed 1", Macro.attack())
         )
         // Using while_ here in case you run out of mp

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -327,6 +327,10 @@ export function withMacro<T>(macro: Macro, action: () => T): T {
 }
 
 export function main(): void {
-  Macro.load().submit();
+  if (have($effect`Eldritch Attunement`)) {
+    Macro.if_("monstername eldritch tentacle", Macro.basicCombat()).step(Macro.load()).submit();
+  } else {
+    Macro.load().submit();
+  }
   while (inMultiFight()) runCombat();
 }

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -51,13 +51,13 @@ export class Macro extends LibramMacro {
     return super.submit();
   }
 
-  tryHaveSkill(skillOrName: Skill | string | null): Macro {
+  tryHaveSkill(skillOrName: Skill | null): Macro {
     if (!skillOrName) return this;
     const skill = typeof skillOrName === "string" ? Skill.get(skillOrName) : skillOrName;
     return this.externalIf(haveSkill(skill), Macro.skill(skill));
   }
 
-  static tryHaveSkill(skillOrName: Skill | string): Macro {
+  static tryHaveSkill(skillOrName: Skill | null): Macro {
     return new Macro().tryHaveSkill(skillOrName);
   }
 
@@ -238,7 +238,7 @@ export class Macro extends LibramMacro {
 
   startCombat(): Macro {
     return this.tryHaveSkill($skill`Sing Along`)
-      .tryHaveSkill("Curse of Weaksauce")
+      .tryHaveSkill($skill`Curse of Weaksauce`)
       .trySkill($skill`Pocket Crumbs`)
       .trySkill($skill`Extract`)
       .tryItem($item`porquoise-handled sixgun`)

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -284,16 +284,25 @@ export class Macro extends LibramMacro {
   }
 
   kill(): Macro {
-    // Using while_ here in case you run out of mp
-    return this.while_("!pastround 20 && !hppercentbelow 25 && !missed 1", Macro.attack())
-      .while_("hasskill Saucegeyser", Macro.skill($skill`Saucegeyser`))
-      .while_("hasskill Weapon of the Pastalord", Macro.skill($skill`Weapon of the Pastalord`))
-      .while_("hasskill Saucestorm", Macro.skill($skill`Saucestorm`))
-      .while_("hasskill Cannelloni Cannon", Macro.skill($skill`Cannelloni Cannon`))
-      .while_("hasskill Wave of Sauce", Macro.skill($skill`Wave of Sauce`))
-      .while_("hasskill Lunging Thrust-Smack", Macro.skill($skill`Lunging Thrust-Smack`))
-      .attack()
-      .repeat();
+    return (
+      this.externalIf(
+        myClass() === $class`Sauceror`,
+        Macro.tryHaveSkill($skill`Curse of Weaksauce`)
+      )
+        .externalIf(
+          myClass() !== $class`Sauceror`,
+          Macro.while_("!pastround 20 && !hppercentbelow 25 && !missed 1", Macro.attack())
+        )
+        // Using while_ here in case you run out of mp
+        .while_("hasskill Saucegeyser", Macro.skill($skill`Saucegeyser`))
+        .while_("hasskill Weapon of the Pastalord", Macro.skill($skill`Weapon of the Pastalord`))
+        .while_("hasskill Cannelloni Cannon", Macro.skill($skill`Cannelloni Cannon`))
+        .while_("hasskill Wave of Sauce", Macro.skill($skill`Wave of Sauce`))
+        .while_("hasskill Saucestorm", Macro.skill($skill`Saucestorm`))
+        .while_("hasskill Lunging Thrust-Smack", Macro.skill($skill`Lunging Thrust-Smack`))
+        .attack()
+        .repeat()
+    );
   }
 
   static kill(): Macro {

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -204,6 +204,7 @@ export class Macro extends LibramMacro {
         .externalIf(
           [
             $familiar`Cocoabo`,
+            $familiar`Feather Boa Constrictor`,
             $familiar`Ninja Pirate Zombie Robot`,
             $familiar`Stocking Mimic`,
           ].some((familiar) => myFamiliar() === familiar),
@@ -237,6 +238,7 @@ export class Macro extends LibramMacro {
         .externalIf(
           [
             $familiar`Cocoabo`,
+            $familiar`Feather Boa Constrictor`,
             $familiar`Ninja Pirate Zombie Robot`,
             $familiar`Stocking Mimic`,
           ].some((familiar) => myFamiliar() === familiar),
@@ -275,9 +277,12 @@ export class Macro extends LibramMacro {
         Macro.while_("!pastround 3 && !hppercentbelow 25", Macro.item("seal tooth"))
       )
       .externalIf(
-        [$familiar`Cocoabo`, $familiar`Ninja Pirate Zombie Robot`, $familiar`Stocking Mimic`].some(
-          (familiar) => myFamiliar() === familiar
-        ),
+        [
+          $familiar`Cocoabo`,
+          $familiar`Feather Boa Constrictor`,
+          $familiar`Ninja Pirate Zombie Robot`,
+          $familiar`Stocking Mimic`,
+        ].some((familiar) => myFamiliar() === familiar),
         Macro.while_("!pastround 10 && !hppercentbelow 25", Macro.item("seal tooth"))
       )
       .externalIf(

--- a/src/dailies.ts
+++ b/src/dailies.ts
@@ -571,7 +571,7 @@ export function hipsterFishing(): void {
       targetLocation,
       Macro.if_(
         `(monsterid 969) || (monsterid 970) || (monsterid 971) || (monsterid 972) || (monsterid 973) || (monstername Black Crayon *)`,
-        Macro.meatKill()
+        Macro.basicCombat()
       ).step(runSource.macro)
     );
   }

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -1004,7 +1004,15 @@ const freeFightSources = [
 
   new FreeFight(
     () => (have($familiar`Machine Elf`) ? clamp(5 - get("_machineTunnelsAdv"), 0, 5) : 0),
-    () => adv1($location`The Deep Machine Tunnels`, -1, ""),
+    () => {
+      withMacro(
+        Macro.if_("monstername Perceiver of Sensations", Macro.tryItem($item`abstraction: thought`))
+          .if_("monstername Perceiver of Thoughts", Macro.tryItem($item`abstraction: action`))
+          .if_("monstername Perceiver of Actions", Macro.tryItem($item`abstraction: sensation`))
+          .basicCombat(),
+        () => adv1($location`The Deep Machine Tunnels`, -1, "")
+      );
+    },
     {
       familiar: () => $familiar`Machine Elf`,
     }

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -655,7 +655,7 @@ class FreeFight {
       freeFightMood().execute();
       freeFightOutfit(this.options.requirements ? this.options.requirements() : []);
       safeRestore();
-      withMacro(Macro.meatKill(), this.run);
+      withMacro(Macro.basicCombat(), this.run);
       horseradish();
       // Slot in our Professor Thesis if it's become available
       if (thesisReady()) deliverThesis();
@@ -672,7 +672,7 @@ const pygmyMacro = Macro.if_(
     Macro.trySkill("Feel Hatred").item($item`divine champagne popper`)
   )
   .if_("monstername pygmy janitor", Macro.item($item`tennis ball`))
-  .if_("monstername time-spinner prank", Macro.meatKill())
+  .if_("monstername time-spinner prank", Macro.basicCombat())
   .abort();
 
 const freeFightSources = [
@@ -764,7 +764,16 @@ const freeFightSources = [
         get("lastGuildStoreOpen") === myAscensions() ? 1 : 3,
         $item`seal-blubber candle`
       );
-      use(figurine);
+      withMacro(
+        Macro.startCombat()
+          .trySkill("Furious Wallop")
+          .while_("hasskill Lunging Thrust-Smack", Macro.skill($skill`Lunging Thrust-Smack`))
+          .while_("hasskill Thrust-Smack", Macro.skill($skill`Thrust-Smack`))
+          .while_("hasskill Lunge Smack", Macro.skill($skill`Lunge Smack`))
+          .attack()
+          .repeat(),
+        () => use(figurine)
+      );
     },
     {
       requirements: () => [new Requirement(["Club"], {})],
@@ -948,7 +957,7 @@ const freeFightSources = [
       if (SourceTerminal.have()) {
         SourceTerminal.educate([$skill`Extract`, $skill`Portscan`]);
       }
-      adventureMacro($location`Your Mushroom Garden`, Macro.trySkill("Portscan").meatKill());
+      adventureMacro($location`Your Mushroom Garden`, Macro.trySkill("Portscan").basicCombat());
       if (have($item`packet of tall grass seeds`)) use($item`packet of tall grass seeds`);
     },
     {
@@ -973,7 +982,7 @@ const freeFightSources = [
         $location`Your Mushroom Garden`,
         Macro.if_("monstername government agent", Macro.skill("Macrometeorite")).if_(
           "monstername piranha plant",
-          Macro.trySkill("Portscan").meatKill()
+          Macro.trySkill("Portscan").basicCombat()
         )
       );
       if (have($item`packet of tall grass seeds`)) use($item`packet of tall grass seeds`);
@@ -1025,7 +1034,7 @@ const freeFightSources = [
         : 0,
     () => {
       nepQuest();
-      adventureMacro($location`The Neverending Party`, Macro.trySkill("Feel Pride").meatKill());
+      adventureMacro($location`The Neverending Party`, Macro.trySkill("Feel Pride").basicCombat());
       if (get("choiceAdventure1324") !== 5 && questStep("_questPartyFair") > 0) {
         print("Found Gerald/ine!", "blue");
         setChoice(1324, 5);
@@ -1254,6 +1263,6 @@ function doSausage() {
   if (!kramcoGuaranteed()) return;
   useFamiliar(freeFightFamiliar());
   freeFightOutfit([new Requirement([], { forceEquip: $items`Kramco Sausage-o-Matic™` })]);
-  adventureMacroAuto(prepWandererZone(), Macro.meatKill());
+  adventureMacroAuto(prepWandererZone(), Macro.basicCombat());
   setAutoAttack(0);
 }

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -1006,9 +1006,24 @@ const freeFightSources = [
     () => (have($familiar`Machine Elf`) ? clamp(5 - get("_machineTunnelsAdv"), 0, 5) : 0),
     () => {
       withMacro(
-        Macro.if_("monstername Perceiver of Sensations", Macro.tryItem($item`abstraction: thought`))
-          .if_("monstername Perceiver of Thoughts", Macro.tryItem($item`abstraction: action`))
-          .if_("monstername Perceiver of Actions", Macro.tryItem($item`abstraction: sensation`))
+        Macro.externalIf(
+          saleValue($item`abstraction: certainty`) > saleValue($item`abstraction: thought`),
+          Macro.if_(
+            "monstername Perceiver of Sensations",
+            Macro.tryItem($item`abstraction: thought`)
+          )
+        )
+          .externalIf(
+            saleValue($item`abstraction: joy`) > saleValue($item`abstraction: action`),
+            Macro.if_("monstername Thinker of Thoughts", Macro.tryItem($item`abstraction: action`))
+          )
+          .externalIf(
+            saleValue($item`abstraction: motion`) > saleValue($item`abstraction: sensation`),
+            Macro.if_(
+              "monstername Performer of Actions",
+              Macro.tryItem($item`abstraction: sensation`)
+            )
+          )
           .basicCombat(),
         () => adv1($location`The Deep Machine Tunnels`, -1, "")
       );

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -103,7 +103,6 @@ import {
 } from "./outfit";
 import { bathroomFinance } from "./potions";
 import { estimatedTurns, globalOptions, log } from "./globalvars";
-import { acquire } from "./acquire";
 import { getString } from "libram/dist/property";
 
 function checkFax(): boolean {

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -100,6 +100,7 @@ import {
 } from "./outfit";
 import { bathroomFinance } from "./potions";
 import { estimatedTurns, log } from "./globalvars";
+import { acquire } from "./acquire";
 
 function checkFax(): boolean {
   if (!have($item`photocopied monster`)) cliExecute("fax receive");
@@ -1005,20 +1006,29 @@ const freeFightSources = [
   new FreeFight(
     () => (have($familiar`Machine Elf`) ? clamp(5 - get("_machineTunnelsAdv"), 0, 5) : 0),
     () => {
+      if (saleValue($item`abstraction: certainty`) >= saleValue($item`abstraction: thought`)) {
+        acquire(1, $item`abstraction: thought`, saleValue($item`abstraction: certainty`), false);
+      }
+      if (saleValue($item`abstraction: joy`) >= saleValue($item`abstraction: action`)) {
+        acquire(1, $item`abstraction: action`, saleValue($item`abstraction: joy`), false);
+      }
+      if (saleValue($item`abstraction: motion`) >= saleValue($item`abstraction: sensation`)) {
+        acquire(1, $item`abstraction: sensation`, saleValue($item`abstraction: motion`), false);
+      }
       withMacro(
         Macro.externalIf(
-          saleValue($item`abstraction: certainty`) > saleValue($item`abstraction: thought`),
+          saleValue($item`abstraction: certainty`) >= saleValue($item`abstraction: thought`),
           Macro.if_(
             "monstername Perceiver of Sensations",
             Macro.tryItem($item`abstraction: thought`)
           )
         )
           .externalIf(
-            saleValue($item`abstraction: joy`) > saleValue($item`abstraction: action`),
+            saleValue($item`abstraction: joy`) >= saleValue($item`abstraction: action`),
             Macro.if_("monstername Thinker of Thoughts", Macro.tryItem($item`abstraction: action`))
           )
           .externalIf(
-            saleValue($item`abstraction: motion`) > saleValue($item`abstraction: sensation`),
+            saleValue($item`abstraction: motion`) >= saleValue($item`abstraction: sensation`),
             Macro.if_(
               "monstername Performer of Actions",
               Macro.tryItem($item`abstraction: sensation`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,14 +68,7 @@ import {
 import { horseradish, runDiet } from "./diet";
 import { freeFightFamiliar, meatFamiliar } from "./familiar";
 import { dailyFights, freeFights, safeRestore } from "./fights";
-import {
-  kramcoGuaranteed,
-  physicalImmuneMacro,
-  prepWandererZone,
-  propertyManager,
-  questStep,
-  Requirement,
-} from "./lib";
+import { kramcoGuaranteed, prepWandererZone, propertyManager, questStep, Requirement } from "./lib";
 import { meatMood } from "./mood";
 import {
   familiarWaterBreathingEquipment,
@@ -195,7 +188,7 @@ function barfTurn() {
   ) {
     useFamiliar(freeFightFamiliar());
     freeFightOutfit([new Requirement([], { forceEquip: $items`protonic accelerator pack` })]);
-    adventureMacro(ghostLocation, physicalImmuneMacro);
+    adventureMacro(ghostLocation, Macro.ghostBustin());
   } else if (
     myInebriety() <= inebrietyLimit() &&
     have($item`"I Voted!" sticker`) &&
@@ -204,11 +197,11 @@ function barfTurn() {
   ) {
     useFamiliar(freeFightFamiliar());
     freeFightOutfit([new Requirement([], { forceEquip: $items`"I Voted!" sticker` })]);
-    adventureMacroAuto(prepWandererZone(), Macro.step(physicalImmuneMacro).meatKill());
+    adventureMacroAuto(prepWandererZone(), Macro.basicCombat());
   } else if (myInebriety() <= inebrietyLimit() && !embezzlerUp && kramcoGuaranteed()) {
     useFamiliar(freeFightFamiliar());
     freeFightOutfit([new Requirement([], { forceEquip: $items`Kramco Sausage-o-Matic™` })]);
-    adventureMacroAuto(prepWandererZone(), Macro.meatKill());
+    adventureMacroAuto(prepWandererZone(), Macro.basicCombat());
   } else {
     if (
       have($item`unwrapped knock-off retro superhero cape`) &&

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -262,15 +262,6 @@ export class Requirement {
   }
 }
 
-export const physicalImmuneMacro = Macro.trySkill("curse of weaksauce")
-  .trySkill("sing along")
-  .trySkill("extract")
-  .externalIf(have($skill`Saucestorm`), Macro.skill("Saucestorm").repeat())
-  .externalIf(have($skill`Saucegeyser`), Macro.skill("Saucegeyser").repeat())
-  .externalIf(have($skill`Cannelloni Cannon`), Macro.skill("Cannelloni Cannon").repeat())
-  .externalIf(have($skill`Wave of Sauce`), Macro.skill("Wave of Sauce").repeat())
-  .externalIf(have($skill`Saucecicle`), Macro.skill("Saucecicle").repeat()); //The Freezewoman is spooky-aligned, don't worry
-
 export function tryFeast(familiar: Familiar): void {
   if (have(familiar)) {
     useFamiliar(familiar);

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -524,6 +524,13 @@ function maxFamiliarDamage(familiar: Familiar): number {
   switch (familiar) {
     case $familiar`Cocoabo`:
       return familiarWeight(familiar) + 3;
+    case $familiar`Feather Boa Constrictor`:
+      // Double sleaze damage at Barf Mountain
+      return (
+        familiarWeight(familiar) +
+        3 +
+        numericModifier("Sleaze Damage") * (myLocation() === $location`Barf Mountain` ? 2 : 1)
+      );
     case $familiar`Ninja Pirate Zombie Robot`:
       return Math.floor((familiarWeight(familiar) + 3) * 1.5);
   }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -3,11 +3,13 @@ import {
   autosellPrice,
   buy,
   cliExecute,
+  familiarWeight,
   haveEquipped,
   haveSkill,
   mallPrice,
   myBjornedFamiliar,
   myEnthronedFamiliar,
+  myFamiliar,
   myLocation,
   numericModifier,
   print,
@@ -507,6 +509,16 @@ function maxCarriedFamiliarDamage(familiar: Familiar): number {
   return 0;
 }
 
+function maxFamiliarDamage(familiar: Familiar): number {
+  switch (familiar) {
+    case $familiar`Cocoabo`:
+      return familiarWeight(familiar) + 3;
+    case $familiar`Ninja Pirate Zombie Robot`:
+      return Math.floor((familiarWeight(familiar) + 3) * 1.5);
+  }
+  return 0;
+}
+
 export function maxPassiveDamage(): number {
   // Only considering passive damage sources we reasonably may have
   const vykeaMaxDamage =
@@ -520,5 +532,7 @@ export function maxPassiveDamage(): number {
     ? maxCarriedFamiliarDamage(myBjornedFamiliar())
     : 0;
 
-  return vykeaMaxDamage + crownMaxDamage + bjornMaxDamage;
+  const familiarMaxDamage = maxFamiliarDamage(myFamiliar());
+
+  return vykeaMaxDamage + crownMaxDamage + bjornMaxDamage + familiarMaxDamage;
 }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -3,8 +3,13 @@ import {
   autosellPrice,
   buy,
   cliExecute,
+  haveEquipped,
   haveSkill,
   mallPrice,
+  myBjornedFamiliar,
+  myEnthronedFamiliar,
+  myLocation,
+  numericModifier,
   print,
   restoreMp,
   toUrl,
@@ -458,4 +463,62 @@ export function saleValue(...items: Item[]): number {
 
 export function kramcoGuaranteed(): boolean {
   return have($item`Kramco Sausage-o-Matic™`) && getKramcoWandererChance() >= 1;
+}
+
+let monsterManuelCached: boolean | undefined = undefined;
+export function monsterManuelAvailable(): boolean {
+  if (monsterManuelCached !== undefined) return Boolean(monsterManuelCached);
+  monsterManuelCached = visitUrl("questlog.php?which=6").includes("Monster Manuel");
+  return Boolean(monsterManuelCached);
+}
+
+function maxCarriedFamiliarDamage(familiar: Familiar): number {
+  // Only considering familiars we reasonably may carry
+  switch (familiar) {
+    // +5 to Familiar Weight
+    case $familiar`Animated Macaroni Duck`:
+      return 50;
+    case $familiar`Barrrnacle`:
+    case $familiar`Gelatinous Cubeling`:
+    case $familiar`Penguin Goodfella`:
+      return 30;
+    case $familiar`Misshapen Animal Skeleton`:
+      return 40 + numericModifier("Spooky Damage");
+
+    // +25% Meat from Monsters
+    case $familiar`Hobo Monkey`:
+      return 25;
+
+    // +20% Meat from Monsters
+    case $familiar`Grouper Groupie`:
+      // Double sleaze damage at Barf Mountain
+      return (
+        25 + numericModifier("Sleaze Damage") * (myLocation() === $location`Barf Mountain` ? 2 : 1)
+      );
+    case $familiar`Jitterbug`:
+      return 20;
+    case $familiar`Mutant Cactus Bud`:
+      // 25 poison damage (25+12+6+3+1)
+      return 47;
+    case $familiar`Robortender`:
+      return 20;
+  }
+
+  return 0;
+}
+
+export function maxPassiveDamage(): number {
+  // Only considering passive damage sources we reasonably may have
+  const vykeaMaxDamage =
+    get("_VYKEACompanionLevel") > 0 ? 10 * get("_VYKEACompanionLevel") + 10 : 0;
+
+  const crownMaxDamage = haveEquipped($item`Crown of Thrones`)
+    ? maxCarriedFamiliarDamage(myEnthronedFamiliar())
+    : 0;
+
+  const bjornMaxDamage = haveEquipped($item`Buddy Bjorn`)
+    ? maxCarriedFamiliarDamage(myBjornedFamiliar())
+    : 0;
+
+  return vykeaMaxDamage + crownMaxDamage + bjornMaxDamage;
 }


### PR DESCRIPTION
- use simpler macro for all non-meat fights
- kill() Macro that nukes if regular attacks miss, hp falls below 25%, or past round 20
- ghost bustin, ensure enough stuns can be used to not get hit
- seal clubbin, use Furious Wallop and smacks
- use $skill & $item instead of strings where appropriate
- inject a macro that can deal with tentacles if you have eldritch attunement
- use Extract, Pocket Crumbs, & porquoise-handled sixgun in meatKill() by checking monster hp and passive damage from vykea + other passive damage sources (monster manuel only)
- use abstraction on machine tunnel monsters to get item if profitable
- tryHaveSkill doesn't need to accept a string, be explicit. Use for all skills that aren't dynamic
- add tryHaveItem to simplify macro more if reusable combat items are unavailable before the fight start
- kill with a sauce spell if a sauceror for weaksauce mp when not using crits for meat
- add cocoabo, boa, & npzr stasis support