### PR TITLE
Don't force memory chip in prof meatchain

### DIFF
--- a/src/fights.ts
+++ b/src/fights.ts
@@ -507,8 +507,32 @@ export function dailyFights(): void {
       }
 
       startDigitize();
-
+      
       // SECOND EMBEZZLER CHAIN
+      if (have($familiar`Pocket Professor`) && !get<boolean>("_garbo_chipChain", false)) {
+        const startLectures = get("_pocketProfessorLectures");
+        const fightSource = getEmbezzlerFight();
+        if (!fightSource) return;
+        useFamiliar($familiar`Pocket Professor`);
+        meatOutfit(true, [
+          ...fightSource.requirements,
+          new Requirement([], { forceEquip: $items`Pocket Professor memory chip` }),
+        ]);
+        if (
+          get("_pocketProfessorLectures") <
+          2 + Math.ceil(Math.sqrt(familiarWeight(myFamiliar()) + weightAdjustment()))
+        ) {
+          withMacro(firstChainMacro(), () =>
+            fightSource.run({ location: prepWandererZone(), macro: firstChainMacro() })
+          );
+          log.initialEmbezzlersFought += 1 + get("_pocketProfessorLectures") - startLectures;
+        }
+        set("_garbo_chipChain", true);
+      }
+      
+      startDigitize();
+
+      // THIRD EMBEZZLER CHAIN
       if (have($familiar`Pocket Professor`) && !get<boolean>("_garbo_weightChain", false)) {
         const startLectures = get("_pocketProfessorLectures");
         const fightSource = getEmbezzlerFight();

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -352,7 +352,15 @@ const embezzlerSources = [
   new EmbezzlerFight(
     "Professor MeatChain",
     () => false,
-    () => (have($familiar`Pocket Professor`) && !get<boolean>("_garbo_meatChain", false) ? 10 : 0),
+    () => (have($familiar`Pocket Professor`) && !get<boolean>("_garbo_meatChain", false) ? 8 : 0),
+    () => {
+      return;
+    }
+  ),
+  new EmbezzlerFight(
+    "Professor ChipChain",
+    () => false,
+    () => (have($familiar`Pocket Professor`) && !get<boolean>("_garbo_chipChain", false) ? 2 : 0),
     () => {
       return;
     }

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -507,7 +507,7 @@ export function dailyFights(): void {
       }
 
       startDigitize();
-      
+
       // SECOND EMBEZZLER CHAIN
       if (have($familiar`Pocket Professor`) && !get<boolean>("_garbo_chipChain", false)) {
         const startLectures = get("_pocketProfessorLectures");
@@ -529,7 +529,7 @@ export function dailyFights(): void {
         }
         set("_garbo_chipChain", true);
       }
-      
+
       startDigitize();
 
       // THIRD EMBEZZLER CHAIN

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -495,7 +495,6 @@ export function dailyFights(): void {
         useFamiliar($familiar`Pocket Professor`);
         meatOutfit(true, [
           ...fightSource.requirements,
-          new Requirement([], { forceEquip: $items`Pocket Professor memory chip` }),
         ]);
         if (
           get("_pocketProfessorLectures") <

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -493,9 +493,7 @@ export function dailyFights(): void {
         const fightSource = getEmbezzlerFight();
         if (!fightSource) return;
         useFamiliar($familiar`Pocket Professor`);
-        meatOutfit(true, [
-          ...fightSource.requirements,
-        ]);
+        meatOutfit(true, [...fightSource.requirements]);
         if (
           get("_pocketProfessorLectures") <
           2 + Math.ceil(Math.sqrt(familiarWeight(myFamiliar()) + weightAdjustment()))


### PR DESCRIPTION
We're forcing the memory chip to be equipped during the prof meat chain... for some reason.
Shouldn't it be better to allow amulet coin to be equipped or something?