### PR TITLE
Add Heavy Rains support

### DIFF
--- a/src/fights.ts
+++ b/src/fights.ts
@@ -233,8 +233,8 @@ const embezzlerSources = [
     () => myRain() >= 50 && have($skill`Rain Man`),
     () => have($skill`Rain Man`) ? Math.floor(myRain() / 50) : 0,
     (options: EmbezzlerFightOptions) => {
-      visitUrl("runskillz.php?action=Skillz&whichskill=16011&targetplayer=" + myId() + "&pwd=&quantity=1");
-      visitUrl("choice.php?pwd=&whichchoice=970&option=1&whichmonster=" + $monster`Knob Goblin Embezzler`.id);
+      visitUrl(`runskillz.php?action=Skillz&whichskill=16011&targetplayer=${myId()}&pwd=&quantity=1`);
+      visitUrl(`choice.php?pwd=&whichchoice=970&option=1&whichmonster=${$monster`Knob Goblin Embezzler`.id}`);
       runCombat(options.macro ? options.macro.toString() : embezzlerMacro().toString());
     }
   ),

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -231,7 +231,7 @@ const embezzlerSources = [
   new EmbezzlerFight(
     "Rain Man",
     () => myRain() >= 50 && have($skill`Rain Man`),
-    () => Math.floor(myRain() / 50),
+    () => have($skill`Rain Man`) ? Math.floor(myRain() / 50) : 0,
     (options: EmbezzlerFightOptions) => {
       visitUrl("runskillz.php?action=Skillz&whichskill=16011&targetplayer=" + myId() + "&pwd=&quantity=1");
       visitUrl("choice.php?pwd=&whichchoice=970&option=1&whichmonster=" + $monster`Knob Goblin Embezzler`.id);

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -22,10 +22,13 @@ import {
   myFamiliar,
   myHash,
   myHp,
+  myId,
   myInebriety,
+  myLightning,
   myMaxhp,
   myMaxmp,
   myMp,
+  myRain,
   mySpleenUse,
   numericModifier,
   outfit,
@@ -222,6 +225,18 @@ const embezzlerSources = [
     },
     [],
     true
+  ),
+  // We want to fight Rain Man embezzlers early to make room for more rain
+  // But we can't put off a digitize embezzler, so we do it second
+  new EmbezzlerFight(
+    "Rain Man",
+    () => myRain() >= 50 && have($skill`Rain Man`),
+    () => Math.floor(myRain() / 50),
+    (options: EmbezzlerFightOptions) => {
+      visitUrl("runskillz.php?action=Skillz&whichskill=16011&targetplayer=" + myId() + "&pwd=&quantity=1");
+      visitUrl("choice.php?pwd=&whichchoice=970&option=1&whichmonster=" + $monster`Knob Goblin Embezzler`.id);
+      runCombat(options.macro ? options.macro.toString() : embezzlerMacro().toString());
+    }
   ),
   new EmbezzlerFight(
     "Backup",
@@ -479,7 +494,7 @@ function embezzlerSetup() {
   }
 }
 
-function getEmbezzlerFight(): EmbezzlerFight | null {
+export function getEmbezzlerFight(): EmbezzlerFight | null {
   for (const fight of embezzlerSources) {
     if (fight.available()) return fight;
   }
@@ -1113,6 +1128,18 @@ const freeFightSources = [
 ];
 
 const freeKillSources = [
+  new FreeFight(
+    () => myLightning() >= 20 && have($skill`Lightning Strike`),
+    () =>
+      withMacro(Macro.skill("Sing Along").trySkill("Lightning Strike"), () =>
+        use($item`drum machine`)
+      ),
+    {
+      familiar: bestFairy,
+      requirements: () => [new Requirement(["100 Item Drop"], {})],
+    }
+  ),
+
   new FreeFight(
     () => !get("_gingerbreadMobHitUsed") && have($skill`Gingerbread Mob Hit`),
     () =>

--- a/src/globalvars.ts
+++ b/src/globalvars.ts
@@ -3,7 +3,7 @@ import { $item, have } from "libram";
 
 export const log = {
   initialEmbezzlersFought: 0,
-  digitizedEmbezzlersFought: 0,
+  middayEmbezzlersFought: 0,
 };
 
 export const globalOptions: { ascending: boolean; stopTurncount: number | null } = {

--- a/src/mood.ts
+++ b/src/mood.ts
@@ -7,6 +7,7 @@ import {
   haveSkill,
   myClass,
   myEffects,
+  myPath,
   mySpleenUse,
   spleenLimit,
   toSkill,
@@ -46,6 +47,7 @@ export function meatMood(urKels = false, embezzlers = false): Mood {
   mood.potion($item`resolution: be wealthier`, 0.3 * baseMeat);
   mood.potion($item`resolution: be happier`, 0.15 * 0.45 * 0.8 * 200);
   mood.potion($item`Flaskfull of Hollow`, 5);
+  if (myPath() === "Heavy Rains") mood.potion($item`catfish whiskers`, 20); // 1/10th of a bag of park garbage
 
   mood.skill($skill`Blood Bond`);
   mood.skill($skill`Leash of Linguini`);
@@ -140,6 +142,9 @@ export function freeFightMood(): Mood {
   if (questStep("questL06Friar") === 999 && !get("friarsBlessingReceived")) {
     cliExecute("friars familiar");
   }
+
+  // value higher than for meat farming because more valuable stuff could wash away? I dunno
+  if (myPath() === "Heavy Rains") mood.potion($item`catfish whiskers`, 50);
 
   return mood;
 }


### PR DESCRIPTION
Rain Man embezzlers and lightning strike free kills so far.

TODO:
1) Consider equipping Thor's Pliers for more lightning strikes
2) Probably stop using lightning strikes on worms, saving them for Heavy Rains wanderers instead
3) Probably shift rain man to be later if you don't have manuel, so that you've definitely fought at least one embezzler that life time before using rain man.