### PR TITLE
remove "Leprechaun" and "Fairy" modifiers from meatFamiliar()

### DIFF
--- a/src/dailies.ts
+++ b/src/dailies.ts
@@ -594,5 +594,5 @@ export function martini(): void {
   ) {
     return;
   }
-  cliExecute("briefcase collect");
+  cliExecute("Briefcase collect");
 }

--- a/src/familiar.ts
+++ b/src/familiar.ts
@@ -32,7 +32,7 @@ export function meatFamiliar(): Familiar {
       const bestLepMult = numericModifier(bestLeps[0], "Meat Drop", 1, $item`none`);
       _meatFamiliar = bestLeps
         .filter(
-          (familiar) => numericModifier(familiar, "Meat Dros", 1, $item`none`) === bestLepMult
+          (familiar) => numericModifier(familiar, "Meat Drop", 1, $item`none`) === bestLepMult
         )
         .sort(
           (a, b) =>

--- a/src/familiar.ts
+++ b/src/familiar.ts
@@ -26,18 +26,18 @@ export function meatFamiliar(): Familiar {
         .filter(have)
         .sort(
           (a, b) =>
-            numericModifier(b, "Leprechaun", 1, $item`none`) -
-            numericModifier(a, "Leprechaun", 1, $item`none`)
+            numericModifier(b, "Meat Drop", 1, $item`none`) -
+            numericModifier(a, "Meat Drop", 1, $item`none`)
         );
-      const bestLepMult = numericModifier(bestLeps[0], "Leprechaun", 1, $item`none`);
+      const bestLepMult = numericModifier(bestLeps[0], "Meat Drop", 1, $item`none`);
       _meatFamiliar = bestLeps
         .filter(
-          (familiar) => numericModifier(familiar, "Leprechaun", 1, $item`none`) === bestLepMult
+          (familiar) => numericModifier(familiar, "Meat Dros", 1, $item`none`) === bestLepMult
         )
         .sort(
           (a, b) =>
-            numericModifier(b, "Fairy", 1, $item`none`) -
-            numericModifier(a, "Fairy", 1, $item`none`)
+            numericModifier(b, "Item Drop", 1, $item`none`) -
+            numericModifier(a, "Item Drop", 1, $item`none`)
         )[0];
     }
   }


### PR DESCRIPTION
Motivated by billybobsteve's issue in discord, and the following startling result:
```
> js numericModifier(Familiar.get("Leprechaun"), "Leprechaun", 1, Item.get("none"))

Returned: 0.0
```

Not touching bjorn code yet because this is a bit of an emergency patch situation