### PR TITLE
Add command line option to not run barf turns

### DIFF
--- a/src/dailies.ts
+++ b/src/dailies.ts
@@ -48,6 +48,7 @@ import { meatFamiliar } from "./familiar";
 import {
   baseMeat,
   ensureEffect,
+  estimatedTurns,
   findRun,
   prepWandererZone,
   propertyManager,
@@ -59,7 +60,6 @@ import {
 } from "./lib";
 import { freeFightOutfit } from "./outfit";
 import { withStash } from "./clan";
-import { estimatedTurns } from "./globalvars";
 import { Macro } from "./combat";
 
 export function voterSetup(): void {

--- a/src/diet.ts
+++ b/src/diet.ts
@@ -46,7 +46,7 @@ import {
   set,
 } from "libram";
 import { acquire } from "./acquire";
-import { embezzlerCount } from "./fights";
+import { embezzlerCount } from "./embezzlers";
 import { estimatedTurns, globalOptions } from "./globalvars";
 import { baseMeat, clamp, ensureEffect, setChoice } from "./lib";
 

--- a/src/diet.ts
+++ b/src/diet.ts
@@ -47,8 +47,8 @@ import {
 } from "libram";
 import { acquire } from "./acquire";
 import { embezzlerCount } from "./embezzlers";
-import { estimatedTurns, globalOptions } from "./globalvars";
-import { baseMeat, clamp, ensureEffect, setChoice } from "./lib";
+import { globalOptions } from "./globalvars";
+import { baseMeat, clamp, ensureEffect, estimatedTurns, setChoice } from "./lib";
 
 const MPA = get("valueOfAdventure");
 print(`Using adventure value ${MPA}.`, "blue");

--- a/src/embezzlers.ts
+++ b/src/embezzlers.ts
@@ -1,0 +1,260 @@
+import { canAdv } from "canadv.ash";
+import { abort, adv1, chatPrivate, cliExecute, getCounters, itemAmount, use, wait } from "kolmafia";
+import {
+  $familiar,
+  $item,
+  $items,
+  $location,
+  $monster,
+  $skill,
+  adventureMacro,
+  ChateauMantegna,
+  get,
+  have,
+  SourceTerminal,
+} from "libram";
+import { getString } from "libram/dist/property";
+import { Macro } from "./combat";
+import { Requirement, sum } from "./lib";
+
+function checkFax(): boolean {
+  if (!have($item`photocopied monster`)) cliExecute("fax receive");
+  if (getString("photocopyMonster") === "Knob Goblin Embezzler") return true;
+  cliExecute("fax send");
+  return false;
+}
+
+function faxEmbezzler(): void {
+  if (!get("_photocopyUsed")) {
+    if (checkFax()) return;
+    chatPrivate("cheesefax", "Knob Goblin Embezzler");
+    for (let i = 0; i < 3; i++) {
+      wait(10);
+      if (checkFax()) return;
+    }
+    abort("Failed to acquire photocopied Knob Goblin Embezzler.");
+  }
+}
+
+type EmbezzlerFightOptions = {
+  location?: Location;
+  macro?: Macro;
+};
+
+export class EmbezzlerFight {
+  available: () => boolean;
+  potential: () => number;
+  run: (options: EmbezzlerFightOptions) => void;
+  requirements: Requirement[];
+  draggable: boolean;
+  name: string;
+
+  constructor(
+    name: string,
+    available: () => boolean,
+    potential: () => number,
+    run: (options: EmbezzlerFightOptions) => void,
+    requirements: Requirement[] = [],
+    draggable = false
+  ) {
+    this.name = name;
+    this.available = available;
+    this.potential = potential;
+    this.run = run;
+    this.requirements = requirements;
+    this.draggable = draggable;
+  }
+}
+
+export const embezzlerMacro = (): Macro =>
+  Macro.if_(
+    "monstername Knob Goblin Embezzler",
+    Macro.if_("snarfblat 186", Macro.tryCopier($item`pulled green taffy`))
+      .trySkill("Wink At")
+      .trySkill("Fire a badly romantic arrow")
+      .externalIf(
+        get("_sourceTerminalDigitizeMonster") !== $monster`Knob Goblin Embezzler`,
+        Macro.tryCopier($skill`Digitize`)
+      )
+      .tryCopier($item`Spooky Putty sheet`)
+      .tryCopier($item`Rain-Doh black box`)
+      .tryCopier($item`4-d camera`)
+      .tryCopier($item`unfinished ice sculpture`)
+      .meatKill()
+  ).abort();
+
+export const embezzlerSources = [
+  new EmbezzlerFight(
+    "Digitize",
+    () =>
+      get("_sourceTerminalDigitizeMonster") === $monster`Knob Goblin Embezzler` &&
+      getCounters("Digitize Monster", 0, 0).trim() !== "",
+    () => (SourceTerminal.have() && get("_sourceTerminalDigitizeUses") === 0 ? 1 : 0),
+    (options: EmbezzlerFightOptions) => {
+      adv1(options.location || $location`Noob Cave`);
+    },
+    [],
+    true
+  ),
+  new EmbezzlerFight(
+    "Backup",
+    () =>
+      get("lastCopyableMonster") === $monster`Knob Goblin Embezzler` &&
+      have($item`backup camera`) &&
+      get<number>("_backUpUses") < 11,
+    () => (have($item`backup camera`) ? 11 - get<number>("_backUpUses") : 0),
+    (options: EmbezzlerFightOptions) => {
+      const realLocation =
+        options.location && options.location.combatPercent >= 100
+          ? options.location
+          : $location`Noob Cave`;
+      adventureMacro(
+        realLocation,
+        Macro.if_(
+          "!monstername Knob Goblin Embezzler",
+          Macro.skill("Back-Up to Your Last Enemy")
+        ).step(options.macro || embezzlerMacro())
+      );
+    },
+    [
+      new Requirement([], {
+        forceEquip: $items`backup camera`,
+        bonusEquip: new Map([[$item`backup camera`, 5000]]),
+      }),
+    ],
+    true
+  ),
+  new EmbezzlerFight(
+    "Fax",
+    () => have($item`Clan VIP Lounge key`) && !get("_photocopyUsed"),
+    () => (have($item`Clan VIP Lounge key`) && !get("_photocopyUsed") ? 1 : 0),
+    () => {
+      faxEmbezzler();
+      use($item`photocopied monster`);
+    }
+  ),
+  new EmbezzlerFight(
+    "Pillkeeper Semirare",
+    () =>
+      have($item`Eight Days a Week Pill Keeper`) &&
+      canAdv($location`Cobb's Knob Treasury`, true) &&
+      !get("_freePillKeeperUsed"),
+    () =>
+      have($item`Eight Days a Week Pill Keeper`) &&
+      canAdv($location`Cobb's Knob Treasury`, true) &&
+      !get("_freePillKeeperUsed")
+        ? 1
+        : 0,
+    () => {
+      cliExecute("pillkeeper semirare");
+      adv1($location`Cobb's Knob Treasury`);
+    }
+  ),
+  new EmbezzlerFight(
+    "Chateau Painting",
+    () =>
+      ChateauMantegna.have() &&
+      !ChateauMantegna.paintingFought() &&
+      ChateauMantegna.paintingMonster() === $monster`Knob Goblin Embezzler`,
+    () =>
+      ChateauMantegna.have() &&
+      !ChateauMantegna.paintingFought() &&
+      ChateauMantegna.paintingMonster() === $monster`Knob Goblin Embezzler`
+        ? 1
+        : 0,
+    () => ChateauMantegna.fightPainting()
+  ),
+  new EmbezzlerFight(
+    "Spooky Putty & Rain-Doh",
+    () =>
+      (have($item`Spooky Putty monster`) &&
+        get("spookyPuttyMonster") === $monster`Knob Goblin Embezzler`) ||
+      (have($item`Rain-Doh box full of monster`) &&
+        get("rainDohMonster") === $monster`Knob Goblin Embezzler`),
+    () => {
+      if (
+        (have($item`Spooky Putty sheet`) || have($item`Spooky Putty monster`)) &&
+        (have($item`Rain-Doh black box`) || have($item`Rain-Doh box full of monster`))
+      ) {
+        return (
+          6 -
+          get("spookyPuttyCopiesMade") -
+          get("_raindohCopiesMade") +
+          itemAmount($item`Spooky Putty monster`) +
+          itemAmount($item`Rain-Doh box full of monster`)
+        );
+      } else if (have($item`Spooky Putty sheet`) || have($item`Spooky Putty monster`)) {
+        return 5 - get("spookyPuttyCopiesMade") + itemAmount($item`Spooky Putty monster`);
+      } else if (have($item`Rain-Doh black box`) || have($item`Rain-Doh box full of monster`)) {
+        return 5 - get("_raindohCopiesMade") + itemAmount($item`Rain-Doh box full of monster`);
+      }
+      return 0;
+    },
+    () => {
+      if (have($item`Spooky Putty monster`)) return use($item`Spooky Putty monster`);
+      return use($item`Rain-Doh box full of monster`);
+    }
+  ),
+  new EmbezzlerFight(
+    "4-d Camera",
+    () =>
+      have($item`shaking 4-d camera`) &&
+      get("cameraMonster") === $monster`Knob Goblin Embezzler` &&
+      !get("_cameraUsed"),
+    () =>
+      have($item`shaking 4-d camera`) &&
+      get("cameraMonster") === $monster`Knob Goblin Embezzler` &&
+      !get("_cameraUsed")
+        ? 1
+        : 0,
+    () => use($item`shaking 4-d camera`)
+  ),
+  new EmbezzlerFight(
+    "Ice Sculpture",
+    () =>
+      have($item`ice sculpture`) &&
+      get("iceSculptureMonster") === $monster`Knob Goblin Embezzler` &&
+      !get("_iceSculptureUsed"),
+    () =>
+      have($item`ice sculpture`) &&
+      get("iceSculptureMonster") === $monster`Knob Goblin Embezzler` &&
+      !get("_iceSculptureUsed")
+        ? 1
+        : 0,
+    () => use($item`ice sculpture`)
+  ),
+  new EmbezzlerFight(
+    "Green Taffy",
+    () =>
+      have($item`envyfish egg`) &&
+      get("envyfishMonster") === $monster`Knob Goblin Embezzler` &&
+      !get("_envyfishEggUsed"),
+    () =>
+      have($item`envyfish egg`) &&
+      get("envyfishMonster") === $monster`Knob Goblin Embezzler` &&
+      !get("_envyfishEggUsed")
+        ? 1
+        : 0,
+    () => use($item`envyfish egg`)
+  ),
+  new EmbezzlerFight(
+    "Professor MeatChain",
+    () => false,
+    () => (have($familiar`Pocket Professor`) && !get<boolean>("_garbo_meatChain", false) ? 10 : 0),
+    () => {
+      return;
+    }
+  ),
+  new EmbezzlerFight(
+    "Professor WeightChain",
+    () => false,
+    () => (have($familiar`Pocket Professor`) && !get<boolean>("_garbo_weightChain", false) ? 5 : 0),
+    () => {
+      return;
+    }
+  ),
+];
+
+export function embezzlerCount(): number {
+  return sum(embezzlerSources.map((source) => source.potential()));
+}

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -78,6 +78,7 @@ import {
   baseMeat,
   clamp,
   ensureEffect,
+  estimatedTurns,
   findRun,
   FreeRun,
   kramcoGuaranteed,
@@ -97,7 +98,7 @@ import {
   waterBreathingEquipment,
 } from "./outfit";
 import { bathroomFinance } from "./potions";
-import { estimatedTurns, globalOptions, log } from "./globalvars";
+import { globalOptions, log } from "./globalvars";
 import { embezzlerCount, EmbezzlerFight, embezzlerMacro, embezzlerSources } from "./embezzlers";
 
 const firstChainMacro = () =>

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -1,10 +1,7 @@
-import { canAdv } from "canadv.ash";
 import {
-  abort,
   adv1,
   availableAmount,
   booleanModifier,
-  chatPrivate,
   cliExecute,
   closetAmount,
   eat,
@@ -47,7 +44,6 @@ import {
   userConfirm,
   useSkill,
   visitUrl,
-  wait,
   weightAdjustment,
 } from "kolmafia";
 import {
@@ -92,7 +88,6 @@ import {
   Requirement,
   saleValue,
   setChoice,
-  sum,
 } from "./lib";
 import { freeFightMood, meatMood } from "./mood";
 import {
@@ -103,56 +98,7 @@ import {
 } from "./outfit";
 import { bathroomFinance } from "./potions";
 import { estimatedTurns, globalOptions, log } from "./globalvars";
-import { getString } from "libram/dist/property";
-
-function checkFax(): boolean {
-  if (!have($item`photocopied monster`)) cliExecute("fax receive");
-  if (getString("photocopyMonster") === "Knob Goblin Embezzler") return true;
-  cliExecute("fax send");
-  return false;
-}
-
-function faxEmbezzler(): void {
-  if (!get("_photocopyUsed")) {
-    if (checkFax()) return;
-    chatPrivate("cheesefax", "Knob Goblin Embezzler");
-    for (let i = 0; i < 3; i++) {
-      wait(10);
-      if (checkFax()) return;
-    }
-    abort("Failed to acquire photocopied Knob Goblin Embezzler.");
-  }
-}
-
-type EmbezzlerFightOptions = {
-  location?: Location;
-  macro?: Macro;
-};
-
-class EmbezzlerFight {
-  available: () => boolean;
-  potential: () => number;
-  run: (options: EmbezzlerFightOptions) => void;
-  requirements: Requirement[];
-  draggable: boolean;
-  name: string;
-
-  constructor(
-    name: string,
-    available: () => boolean,
-    potential: () => number,
-    run: (options: EmbezzlerFightOptions) => void,
-    requirements: Requirement[] = [],
-    draggable = false
-  ) {
-    this.name = name;
-    this.available = available;
-    this.potential = potential;
-    this.run = run;
-    this.requirements = requirements;
-    this.draggable = draggable;
-  }
-}
+import { embezzlerCount, EmbezzlerFight, embezzlerMacro, embezzlerSources } from "./embezzlers";
 
 const firstChainMacro = () =>
   Macro.if_(
@@ -192,199 +138,6 @@ const secondChainMacro = () =>
         .trySkill("Lecture on Relativity")
     ).meatKill()
   ).abort();
-
-const embezzlerMacro = () =>
-  Macro.if_(
-    "monstername Knob Goblin Embezzler",
-    Macro.if_("snarfblat 186", Macro.tryCopier($item`pulled green taffy`))
-      .trySkill("Wink At")
-      .trySkill("Fire a badly romantic arrow")
-      .externalIf(
-        get("_sourceTerminalDigitizeMonster") !== $monster`Knob Goblin Embezzler`,
-        Macro.tryCopier($skill`Digitize`)
-      )
-      .tryCopier($item`Spooky Putty sheet`)
-      .tryCopier($item`Rain-Doh black box`)
-      .tryCopier($item`4-d camera`)
-      .tryCopier($item`unfinished ice sculpture`)
-      .meatKill()
-  ).abort();
-
-const embezzlerSources = [
-  new EmbezzlerFight(
-    "Digitize",
-    () =>
-      get("_sourceTerminalDigitizeMonster") === $monster`Knob Goblin Embezzler` &&
-      getCounters("Digitize Monster", 0, 0).trim() !== "",
-    () => (SourceTerminal.have() && get("_sourceTerminalDigitizeUses") === 0 ? 1 : 0),
-    (options: EmbezzlerFightOptions) => {
-      adv1(options.location || $location`Noob Cave`);
-    },
-    [],
-    true
-  ),
-  new EmbezzlerFight(
-    "Backup",
-    () =>
-      get("lastCopyableMonster") === $monster`Knob Goblin Embezzler` &&
-      have($item`backup camera`) &&
-      get<number>("_backUpUses") < 11,
-    () => (have($item`backup camera`) ? 11 - get<number>("_backUpUses") : 0),
-    (options: EmbezzlerFightOptions) => {
-      const realLocation =
-        options.location && options.location.combatPercent >= 100
-          ? options.location
-          : $location`Noob Cave`;
-      adventureMacro(
-        realLocation,
-        Macro.if_(
-          "!monstername Knob Goblin Embezzler",
-          Macro.skill("Back-Up to Your Last Enemy")
-        ).step(options.macro || embezzlerMacro())
-      );
-    },
-    [
-      new Requirement([], {
-        forceEquip: $items`backup camera`,
-        bonusEquip: new Map([[$item`backup camera`, 5000]]),
-      }),
-    ],
-    true
-  ),
-  new EmbezzlerFight(
-    "Fax",
-    () => have($item`Clan VIP Lounge key`) && !get("_photocopyUsed"),
-    () => (have($item`Clan VIP Lounge key`) && !get("_photocopyUsed") ? 1 : 0),
-    () => {
-      faxEmbezzler();
-      use($item`photocopied monster`);
-    }
-  ),
-  new EmbezzlerFight(
-    "Pillkeeper Semirare",
-    () =>
-      have($item`Eight Days a Week Pill Keeper`) &&
-      canAdv($location`Cobb's Knob Treasury`, true) &&
-      !get("_freePillKeeperUsed"),
-    () =>
-      have($item`Eight Days a Week Pill Keeper`) &&
-      canAdv($location`Cobb's Knob Treasury`, true) &&
-      !get("_freePillKeeperUsed")
-        ? 1
-        : 0,
-    () => {
-      cliExecute("pillkeeper semirare");
-      adv1($location`Cobb's Knob Treasury`);
-    }
-  ),
-  new EmbezzlerFight(
-    "Chateau Painting",
-    () =>
-      ChateauMantegna.have() &&
-      !ChateauMantegna.paintingFought() &&
-      ChateauMantegna.paintingMonster() === $monster`Knob Goblin Embezzler`,
-    () =>
-      ChateauMantegna.have() &&
-      !ChateauMantegna.paintingFought() &&
-      ChateauMantegna.paintingMonster() === $monster`Knob Goblin Embezzler`
-        ? 1
-        : 0,
-    () => ChateauMantegna.fightPainting()
-  ),
-  new EmbezzlerFight(
-    "Spooky Putty & Rain-Doh",
-    () =>
-      (have($item`Spooky Putty monster`) &&
-        get("spookyPuttyMonster") === $monster`Knob Goblin Embezzler`) ||
-      (have($item`Rain-Doh box full of monster`) &&
-        get("rainDohMonster") === $monster`Knob Goblin Embezzler`),
-    () => {
-      if (
-        (have($item`Spooky Putty sheet`) || have($item`Spooky Putty monster`)) &&
-        (have($item`Rain-Doh black box`) || have($item`Rain-Doh box full of monster`))
-      ) {
-        return (
-          6 -
-          get("spookyPuttyCopiesMade") -
-          get("_raindohCopiesMade") +
-          itemAmount($item`Spooky Putty monster`) +
-          itemAmount($item`Rain-Doh box full of monster`)
-        );
-      } else if (have($item`Spooky Putty sheet`) || have($item`Spooky Putty monster`)) {
-        return 5 - get("spookyPuttyCopiesMade") + itemAmount($item`Spooky Putty monster`);
-      } else if (have($item`Rain-Doh black box`) || have($item`Rain-Doh box full of monster`)) {
-        return 5 - get("_raindohCopiesMade") + itemAmount($item`Rain-Doh box full of monster`);
-      }
-      return 0;
-    },
-    () => {
-      if (have($item`Spooky Putty monster`)) return use($item`Spooky Putty monster`);
-      return use($item`Rain-Doh box full of monster`);
-    }
-  ),
-  new EmbezzlerFight(
-    "4-d Camera",
-    () =>
-      have($item`shaking 4-d camera`) &&
-      get("cameraMonster") === $monster`Knob Goblin Embezzler` &&
-      !get("_cameraUsed"),
-    () =>
-      have($item`shaking 4-d camera`) &&
-      get("cameraMonster") === $monster`Knob Goblin Embezzler` &&
-      !get("_cameraUsed")
-        ? 1
-        : 0,
-    () => use($item`shaking 4-d camera`)
-  ),
-  new EmbezzlerFight(
-    "Ice Sculpture",
-    () =>
-      have($item`ice sculpture`) &&
-      get("iceSculptureMonster") === $monster`Knob Goblin Embezzler` &&
-      !get("_iceSculptureUsed"),
-    () =>
-      have($item`ice sculpture`) &&
-      get("iceSculptureMonster") === $monster`Knob Goblin Embezzler` &&
-      !get("_iceSculptureUsed")
-        ? 1
-        : 0,
-    () => use($item`ice sculpture`)
-  ),
-  new EmbezzlerFight(
-    "Green Taffy",
-    () =>
-      have($item`envyfish egg`) &&
-      get("envyfishMonster") === $monster`Knob Goblin Embezzler` &&
-      !get("_envyfishEggUsed"),
-    () =>
-      have($item`envyfish egg`) &&
-      get("envyfishMonster") === $monster`Knob Goblin Embezzler` &&
-      !get("_envyfishEggUsed")
-        ? 1
-        : 0,
-    () => use($item`envyfish egg`)
-  ),
-  new EmbezzlerFight(
-    "Professor MeatChain",
-    () => false,
-    () => (have($familiar`Pocket Professor`) && !get<boolean>("_garbo_meatChain", false) ? 10 : 0),
-    () => {
-      return;
-    }
-  ),
-  new EmbezzlerFight(
-    "Professor WeightChain",
-    () => false,
-    () => (have($familiar`Pocket Professor`) && !get<boolean>("_garbo_weightChain", false) ? 5 : 0),
-    () => {
-      return;
-    }
-  ),
-];
-
-export function embezzlerCount(): number {
-  return sum(embezzlerSources.map((source) => source.potential()));
-}
 
 function embezzlerSetup() {
   meatMood(true, true).execute(estimatedTurns());

--- a/src/globalvars.ts
+++ b/src/globalvars.ts
@@ -1,7 +1,3 @@
-import { inebrietyLimit, myAdventures, myInebriety, myTurncount } from "kolmafia";
-import { $item, have } from "libram";
-import { embezzlerCount } from "./embezzlers";
-
 export const log = {
   initialEmbezzlersFought: 0,
   digitizedEmbezzlersFought: 0,
@@ -13,15 +9,3 @@ export const globalOptions: { ascending: boolean; stopTurncount: number | null; 
     ascending: false,
     noBarf: false,
   };
-
-export function estimatedTurns(): number {
-  let turns;
-  if (globalOptions.stopTurncount) turns = globalOptions.stopTurncount - myTurncount();
-  else if (globalOptions.noBarf) turns = embezzlerCount();
-  else
-    turns =
-      (myAdventures() + (globalOptions.ascending && myInebriety() <= inebrietyLimit() ? 60 : 0)) *
-      (have($item`mafia thumb ring`) ? 1.04 : 1);
-
-  return turns;
-}

--- a/src/globalvars.ts
+++ b/src/globalvars.ts
@@ -1,19 +1,27 @@
 import { inebrietyLimit, myAdventures, myInebriety, myTurncount } from "kolmafia";
 import { $item, have } from "libram";
+import { embezzlerCount } from "./embezzlers";
 
 export const log = {
   initialEmbezzlersFought: 0,
   digitizedEmbezzlersFought: 0,
 };
 
-export const globalOptions: { ascending: boolean; stopTurncount: number | null } = {
-  stopTurncount: null,
-  ascending: false,
-};
+export const globalOptions: { ascending: boolean; stopTurncount: number | null; noBarf: boolean } =
+  {
+    stopTurncount: null,
+    ascending: false,
+    noBarf: false,
+  };
 
 export function estimatedTurns(): number {
-  return globalOptions.stopTurncount
-    ? globalOptions.stopTurncount - myTurncount()
-    : (myAdventures() + (globalOptions.ascending && myInebriety() <= inebrietyLimit() ? 60 : 0)) *
-        (have($item`mafia thumb ring`) ? 1.04 : 1);
+  let turns;
+  if (globalOptions.stopTurncount) turns = globalOptions.stopTurncount - myTurncount();
+  else if (globalOptions.noBarf) turns = embezzlerCount();
+  else
+    turns =
+      (myAdventures() + (globalOptions.ascending && myInebriety() <= inebrietyLimit() ? 60 : 0)) *
+      (have($item`mafia thumb ring`) ? 1.04 : 1);
+
+  return turns;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -309,6 +309,9 @@ export function main(argString = ""): void {
     if (arg.match(/ascend/)) {
       globalOptions.ascending = true;
     }
+    if (arg.match(/nobarf/)) {
+      globalOptions.noBarf = true;
+    }
   }
   const gardens = $items`packet of pumpkin seeds, Peppermint Pip Packet, packet of dragon's teeth, packet of beer seeds, packet of winter seeds, packet of thanksgarden seeds, packet of tall grass seeds, packet of mushroom spores`;
   const startingGarden = gardens.find((garden) =>
@@ -392,28 +395,30 @@ export function main(argString = ""): void {
         // 0. diet stuff.
         runDiet();
 
-        // 1. get a ticket
-        ensureBarfAccess();
-
-        // 2. make an outfit (amulet coin, pantogram, etc), misc other stuff (VYKEA, songboom, robortender drinks)
+        // 1. make an outfit (amulet coin, pantogram, etc), misc other stuff (VYKEA, songboom, robortender drinks)
         dailySetup();
 
         setDefaultMaximizeOptions({
           preventEquip: $items`broken champagne bottle, Spooky Putty snake, Spooky Putty mitre, Spooky Putty leotard, Spooky Putty ball, papier-mitre`,
         });
 
-        // 4. do some embezzler stuff
+        // 2. do some embezzler stuff
         freeFights();
         dailyFights();
 
-        // 5. burn turns at barf
-        try {
-          while (canContinue()) {
-            barfTurn();
+        if (!globalOptions.noBarf) {
+          // 3. get a ticket
+          ensureBarfAccess();
+
+          // 4. burn turns at barf
+          try {
+            while (canContinue()) {
+              barfTurn();
+            }
+          } finally {
+            setAutoAttack(0);
           }
-        } finally {
-          setAutoAttack(0);
-        }
+        } else setAutoAttack(0);
       });
     });
   } finally {

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,7 @@ import { horseradish, runDiet } from "./diet";
 import { freeFightFamiliar, meatFamiliar } from "./familiar";
 import { dailyFights, freeFights, safeRestore } from "./fights";
 import {
+    estimatedTurns,
   kramcoGuaranteed,
   physicalImmuneMacro,
   prepWandererZone,
@@ -84,7 +85,7 @@ import {
   waterBreathingEquipment,
 } from "./outfit";
 import { withStash, withVIPClan } from "./clan";
-import { estimatedTurns, globalOptions, log } from "./globalvars";
+import { globalOptions, log } from "./globalvars";
 
 // Max price for tickets. You should rethink whether Barf is the best place if they're this expensive.
 const TICKET_MAX_PRICE = 500000;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -4,7 +4,11 @@ import {
   buy,
   cliExecute,
   haveSkill,
+  inebrietyLimit,
   mallPrice,
+  myAdventures,
+  myInebriety,
+  myTurncount,
   print,
   restoreMp,
   toUrl,
@@ -35,6 +39,7 @@ import {
   property,
   SongBoom,
 } from "libram";
+import { embezzlerCount } from "./embezzlers";
 import { globalOptions } from "./globalvars";
 
 export enum BonusEquipMode {
@@ -487,4 +492,16 @@ export function saleValue(...items: Item[]): number {
 
 export function kramcoGuaranteed(): boolean {
   return have($item`Kramco Sausage-o-Matic™`) && getKramcoWandererChance() >= 1;
+}
+
+export function estimatedTurns(): number {
+  let turns;
+  if (globalOptions.stopTurncount) turns = globalOptions.stopTurncount - myTurncount();
+  else if (globalOptions.noBarf) turns = embezzlerCount();
+  else
+    turns =
+      (myAdventures() + (globalOptions.ascending && myInebriety() <= inebrietyLimit() ? 60 : 0)) *
+      (have($item`mafia thumb ring`) ? 1.04 : 1);
+
+  return turns;
 }

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -32,8 +32,8 @@ import {
   maximizeCached,
 } from "libram";
 import { pickBjorn } from "./bjorn";
-import { estimatedTurns, globalOptions } from "./globalvars";
-import { baseMeat, BonusEquipMode, Requirement, saleValue } from "./lib";
+import { globalOptions } from "./globalvars";
+import { baseMeat, BonusEquipMode, estimatedTurns, Requirement, saleValue } from "./lib";
 
 const bestAdventuresFromPants =
   Item.all()

--- a/src/potions.ts
+++ b/src/potions.ts
@@ -25,8 +25,7 @@ import {
   have,
 } from "libram";
 import { acquire } from "./acquire";
-import { baseMeat } from "./lib";
-import { estimatedTurns } from "./globalvars";
+import { baseMeat, estimatedTurns } from "./lib";
 import { embezzlerCount } from "./embezzlers";
 
 const banned = $items`Uncle Greenspan's Bathroom Finance Guide`;

--- a/src/potions.ts
+++ b/src/potions.ts
@@ -25,9 +25,9 @@ import {
   have,
 } from "libram";
 import { acquire } from "./acquire";
-import { embezzlerCount } from "./fights";
 import { baseMeat } from "./lib";
 import { estimatedTurns } from "./globalvars";
+import { embezzlerCount } from "./embezzlers";
 
 const banned = $items`Uncle Greenspan's Bathroom Finance Guide`;
 


### PR DESCRIPTION
Allow user to run `garbo nobarf` to only run free fights and initial embezzler fights.
Diet is still performed before running the fights.
Note that some embezzler logic had to be taken out of fights.js in order to prevent a circular dependency between fights.js and globalvars.js. The refactor is a straight copy-paste.