### PR TITLE
only freerun for carrots if we have cajun and rawhide

### DIFF
--- a/src/fights.ts
+++ b/src/fights.ts
@@ -1290,7 +1290,11 @@ const freeRunFightSources = [
     }
   ),
   new FreeRunFight(
-    () => have($item`latte lovers member's mug`) && !get("latteUnlocks").includes("carrot"),
+    () =>
+      have($item`latte lovers member's mug`) &&
+      !get("latteUnlocks").includes("carrot") &&
+      get("latteUnlocks").includes("cajun") &&
+      get("latteUnlocks").includes("rawhide"),
     (runSource: FreeRun) => {
       adventureMacro($location`The Dire Warren`, runSource.macro);
     },


### PR DESCRIPTION
Carrots are available for all ascension types, including Goo and CS--we don't want to waste free runs getting a carrot latte if we aren't going to ever use that latte, which should only happen if we have rawhide and cajun as ingredients. 