### PR TITLE
Remove free fight mood execute from FreeRunFight

### DIFF
--- a/src/fights.ts
+++ b/src/fights.ts
@@ -751,7 +751,6 @@ class FreeRunFight extends FreeFight {
       useFamiliar(
         this.options.familiar ? this.options.familiar() ?? freeFightFamiliar() : freeFightFamiliar()
       );
-      freeFightMood().execute();
       if (runSource.prepare) runSource.prepare();
       freeFightOutfit([
         ...(this.options.requirements ? this.options.requirements() : []),


### PR DESCRIPTION
There's no reason to execute the mood for a free run since there's no benefit from effects.