### PR TITLE
Add a setting to interrupt garbo

### DIFF
--- a/mafia/data/garbo_settings.txt
+++ b/mafia/data/garbo_settings.txt
@@ -1,9 +1,10 @@
 # variable timing, number, variable name, variable type, description
 # each separated by a tab
 
-setting	0	valueOfAdventure	int	What is a marginal barf turn worth to you?
-setting	1	garbo_stashClan	string	What is your stash clan? Set to current clan if you don't have access to one.
-setting	2	garbo_vipClan	string	What is your vip clan? Set to current clan if you don't have access to one (And then get whitelisted to BAFH. It's free!).
-setting	3	garbo_skipAscensionCheck	boolean	Should skip verifying that your account has broken the prism? Set to true if you want to proceed regardless, and false if you'd like to be warned.
-setting	4	garbo_valueOfFreeFight	int	What is a free fight\run worth to you? (Default 2000).
-# setting	5	useCarpe	boolean	Use carpe? Disabled by default because it's probably rude to use up fish. Don't be rude!
+setting	0	garbo_interrupt	boolean	Set this to true to safely stop the script if it is running.
+setting	1	valueOfAdventure	int	What is a marginal barf turn worth to you?
+setting	2	garbo_stashClan	string	What is your stash clan? Set to current clan if you don't have access to one.
+setting	3	garbo_vipClan	string	What is your vip clan? Set to current clan if you don't have access to one (And then get whitelisted to BAFH. It's free!).
+setting	4	garbo_skipAscensionCheck	boolean	Should skip verifying that your account has broken the prism? Set to true if you want to proceed regardless, and false if you'd like to be warned.
+setting	5	garbo_valueOfFreeFight	int	What is a free fight\run worth to you? (Default 2000).
+# setting	6	useCarpe	boolean	Use carpe? Disabled by default because it's probably rude to use up fish. Don't be rude!

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -96,6 +96,7 @@ import {
   propertyManager,
   questStep,
   Requirement,
+  safeInterrupt,
   saleValue,
   setChoice,
   sum,
@@ -561,6 +562,7 @@ export function dailyFights(): void {
           log.initialEmbezzlersFought += 1 + get("_pocketProfessorLectures") - startLectures;
         }
         set("_garbo_meatChain", true);
+        safeInterrupt();
       }
 
       startDigitize();
@@ -591,6 +593,7 @@ export function dailyFights(): void {
           log.initialEmbezzlersFought += 1 + get("_pocketProfessorLectures") - startLectures;
         }
         set("_garbo_weightChain", true);
+        safeInterrupt();
       }
 
       startDigitize();
@@ -659,6 +662,7 @@ export function dailyFights(): void {
         ) {
           doSausage();
         }
+        safeInterrupt();
       }
 
       // Check in case our prof gained enough exp during the profchains
@@ -726,6 +730,7 @@ class FreeFight {
       horseradish();
       // Slot in our Professor Thesis if it's become available
       if (thesisReady()) deliverThesis();
+      safeInterrupt();
     }
   }
 }
@@ -758,6 +763,7 @@ class FreeRunFight extends FreeFight {
       ]);
       safeRestore();
       withMacro(Macro.step(runSource.macro), () => this.freeRun(runSource));
+      safeInterrupt();
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ import {
   propertyManager,
   questStep,
   Requirement,
+  safeInterrupt,
 } from "./lib";
 import { meatMood } from "./mood";
 import {
@@ -348,6 +349,7 @@ export function main(argString = ""): void {
         try {
           while (canContinue()) {
             barfTurn();
+            safeInterrupt();
           }
         } finally {
           setAutoAttack(0);

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,5 +1,6 @@
 import { canAdv } from "canadv.ash";
 import {
+  abort,
   autosellPrice,
   buy,
   cliExecute,
@@ -42,6 +43,7 @@ import {
   MaximizeOptions,
   PropertiesManager,
   property,
+  set,
   SongBoom,
   SourceTerminal,
 } from "libram";
@@ -61,6 +63,13 @@ export const baseMeat =
   (SongBoom.songChangesLeft() > 0 || SongBoom.song() === "Total Eclipse of Your Meat")
     ? 275
     : 250;
+
+export function safeInterrupt(): void {
+  if (get<boolean>("garbo_interrupt", false)) {
+    set("garbo_interrupt", false);
+    abort("User interrupt requested. Stopping Garbage Collector.");
+  }
+}
 
 export function setChoice(adventure: number, value: number): void {
   propertyManager.setChoices({ [adventure]: value });


### PR DESCRIPTION
I find myself slamming on esc a lot to stop garbo when testing, so here is a way to abort it safely from the relay script instead.

Current points where the abort can happen:

- After a single free fight or kill
- After the entire embezzler meat chain is finished
- After the entire embezzler weight chain is finished
- After any other embezzler fight
- After a single barf fight
