### PR TITLE
Replace hex key (not consumed) by instructions (consumed) in Vykea cost estimation

### DIFF
--- a/src/dailies.ts
+++ b/src/dailies.ts
@@ -291,7 +291,7 @@ function configureVykea() {
       (5 * mallPrice($item`VYKEA rail`) +
         cost * mallPrice($item`VYKEA dowel`) +
         5 * mallPrice($item`VYKEA plank`) +
-        1 * mallPrice($item`VYKEA hex key`));
+        1 * mallPrice($item`VYKEA instructions`));
 
     if (vykeas.some(([level, cost]) => vykeaProfit(level, cost) > 0)) {
       const level = vykeas.sort((a, b) => vykeaProfit(...b) - vykeaProfit(...a))[0][0];


### PR DESCRIPTION
Replaced hex key (not consumed) by instructions (consumed) in vykea cost estimation