### PR TITLE
don't try to put backups in non-backup zones

### DIFF
--- a/src/fights.ts
+++ b/src/fights.ts
@@ -347,7 +347,9 @@ export function dailyFights(): void {
         ) {
           withMacro(firstChainMacro(), () =>
             fightSource.run({
-              location: determineDraggableZoneAndEnsureAccess(),
+              location: determineDraggableZoneAndEnsureAccess(
+                fightSource.name === "backup" ? draggableFight.BACKUP : draggableFight.WANDERER
+              ),
               macro: firstChainMacro(),
             })
           );
@@ -380,7 +382,9 @@ export function dailyFights(): void {
         ) {
           withMacro(secondChainMacro(), () =>
             fightSource.run({
-              location: determineDraggableZoneAndEnsureAccess(),
+              location: determineDraggableZoneAndEnsureAccess(
+                fightSource.name === "backup" ? draggableFight.BACKUP : draggableFight.WANDERER
+              ),
               macro: secondChainMacro(),
             })
           );

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -347,9 +347,6 @@ export function dailyFights(): void {
         ) {
           withMacro(firstChainMacro(), () =>
             fightSource.run({
-              location: determineDraggableZoneAndEnsureAccess(
-                fightSource.name === "backup" ? draggableFight.BACKUP : draggableFight.WANDERER
-              ),
               macro: firstChainMacro(),
             })
           );
@@ -382,9 +379,6 @@ export function dailyFights(): void {
         ) {
           withMacro(secondChainMacro(), () =>
             fightSource.run({
-              location: determineDraggableZoneAndEnsureAccess(
-                fightSource.name === "backup" ? draggableFight.BACKUP : draggableFight.WANDERER
-              ),
               macro: secondChainMacro(),
             })
           );


### PR DESCRIPTION
This is a not-great fix that nevertheless should patch an issue that Scotch ran into earlier today. 

I would like to, in the near future, re-evaluate the relationship between wanderer.ts, fights.ts, and embezzler.ts, because I'm pretty sure there is a way to make this much, much shorter, and that may involve excising location from EmbezzlerOptions. But for now I would like to get this fix in so that it's fixed.