### PR TITLE
prevent all our various equips within the outfit functions

### DIFF
--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -88,7 +88,10 @@ export function freeFightOutfit(requirements: Requirement[] = []): void {
 
   const finalRequirement = new Requirement(parameters, {
     forceEquip: forceEquip,
-    preventEquip: preventEquip,
+    preventEquip: [
+      ...preventEquip,
+      ...$items`broken champagne bottle, Spooky Putty snake, Spooky Putty mitre, Spooky Putty leotard, Spooky Putty ball, papier-mitre, smoke ball`,
+    ],
     bonusEquip: new Map<Item, number>([
       ...bonusEquip,
       ...dropsItems(equipMode),
@@ -229,7 +232,7 @@ export function meatOutfit(
       {
         forceEquip,
         preventEquip: [
-          ...$items`broken champagne bottle`,
+          ...$items`broken champagne bottle, Spooky Putty snake, Spooky Putty mitre, Spooky Putty leotard, Spooky Putty ball, papier-mitre, smoke ball`,
           ...(embezzlerUp ? $items`cheap sunglasses` : []),
           bjornAlike === $item`Buddy Bjorn` ? $item`Crown of Thrones` : $item`Buddy Bjorn`,
         ],


### PR DESCRIPTION
Right now, garbo doesn't actually pass any of our default preventEquips to the maximizer, because it passes a different array of preventEquips. This changes that.