### PR TITLE
hardcode the robortender into meatFamiliar()

### DIFF
--- a/src/familiar.ts
+++ b/src/familiar.ts
@@ -18,6 +18,8 @@ export function meatFamiliar(): Familiar {
       have($item`li'l pirate costume`)
     ) {
       _meatFamiliar = $familiar`Trick-or-Treating Tot`;
+    } else if (have($familiar`Robortender`)) {
+      _meatFamiliar = $familiar`Robortender`;
     } else {
       const bestLeps = Familiar.all()
         .filter(have)


### PR DESCRIPTION
Right now, if an outfit function gets called before a particular function in our daily tasks, we will lock in a non-robortender familiar as our meat familiar. While ultimately easily avoidable, this behavior is bizarre and dumb and can be rectified by this.