### PR TITLE
don't react as poorly to mistimed digitizes

### DIFF
--- a/src/fights.ts
+++ b/src/fights.ts
@@ -322,7 +322,7 @@ function startWandererCounter() {
         Macro.if_($monster`Knob Goblin Embezzler`, embezzlerMacro()).step(run.macro)
       );
     } while (
-      get("lastCopyableMonster") === $monster`Government agent` &&
+      get("lastCopyableMonster") === $monster`Government agent` ||
       get("lastEncounter") === "Lights Out in the Kitchen"
     );
   }

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -309,15 +309,18 @@ function startWandererCounter() {
   )
     return;
   if (
-    (getCounters("Digitize Monster", 0, 100).trim() === "" &&
+    (getCounters("Digitize Monster", -3, 100).trim() === "" &&
       get("_sourceTerminalDigitizeUses") !== 0) ||
-    (getCounters("Enamorang Monster", 0, 100).trim() === "" && get("enamorangMonster"))
+    (getCounters("Enamorang Monster", -3, 100).trim() === "" && get("enamorangMonster"))
   ) {
     do {
       const run = findRun() || ltbRun;
       if (run.prepare) run.prepare();
       freeFightOutfit(run.requirement ? [run.requirement] : []);
-      adventureMacro($location`Noob Cave`, run.macro);
+      adventureMacro(
+        $location`Noob Cave`,
+        Macro.if_($monster`Knob Goblin Embezzler`, embezzlerMacro()).step(run.macro)
+      );
     } while (get("lastCopyableMonster") === $monster`Government agent`);
   }
 }

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -314,9 +314,13 @@ function startWandererCounter() {
     (getCounters("Enamorang Monster", -3, 100).trim() === "" && get("enamorangMonster"))
   ) {
     do {
-      const run = findRun() || ltbRun;
+      const run = findRun(get("beGregariousFightsLeft") === 0) || ltbRun;
       if (run.prepare) run.prepare();
-      freeFightOutfit(run.requirement ? [run.requirement] : []);
+      if (get("beGregariousFightsLeft") > 0) {
+        meatOutfit(true, run.requirement ? [run.requirement] : []);
+      } else {
+        freeFightOutfit(run.requirement ? [run.requirement] : []);
+      }
       adventureMacro(
         $location`The Haunted Kitchen`,
         Macro.if_($monster`Knob Goblin Embezzler`, embezzlerMacro()).step(run.macro)

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -321,13 +321,17 @@ function startWandererCounter() {
       } else {
         freeFightOutfit(run.requirement ? [run.requirement] : []);
       }
+      const targetZone =
+        $locations`The Bat Hole Entrance, The Neverending Party, Pirates of the Garbage Barges, The Bugbear Pen, Thugnderdome, Domed City of Grimacia, The Degrassi Knoll Restroom`.find(
+          (location) => canAdv(location, false)
+        ) ?? $location`The Haunted Kitchen`;
       adventureMacro(
-        $location`The Haunted Kitchen`,
+        targetZone,
         Macro.if_($monster`Knob Goblin Embezzler`, embezzlerMacro()).step(run.macro)
       );
     } while (
       get("lastCopyableMonster") === $monster`Government agent` ||
-      get("lastEncounter") === "Lights Out in the Kitchen"
+      ["Lights Out in the Kitchen", "Play Misty For Me"].includes(get("lastEncounter"))
     );
   }
 }

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -318,10 +318,13 @@ function startWandererCounter() {
       if (run.prepare) run.prepare();
       freeFightOutfit(run.requirement ? [run.requirement] : []);
       adventureMacro(
-        $location`Noob Cave`,
+        $location`The Haunted Kitchen`,
         Macro.if_($monster`Knob Goblin Embezzler`, embezzlerMacro()).step(run.macro)
       );
-    } while (get("lastCopyableMonster") === $monster`Government agent`);
+    } while (
+      get("lastCopyableMonster") === $monster`Government agent` &&
+      get("lastEncounter") === "Lights Out in the Kitchen"
+    );
   }
 }
 

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -321,12 +321,8 @@ function startWandererCounter() {
       } else {
         freeFightOutfit(run.requirement ? [run.requirement] : []);
       }
-      const targetZone =
-        $locations`The Bat Hole Entrance, The Neverending Party, Pirates of the Garbage Barges, The Bugbear Pen, Thugnderdome, Domed City of Grimacia, The Degrassi Knoll Restroom`.find(
-          (location) => canAdv(location, false)
-        ) ?? $location`The Haunted Kitchen`;
       adventureMacro(
-        targetZone,
+        $location`The Haunted Kitchen`,
         Macro.if_($monster`Knob Goblin Embezzler`, embezzlerMacro()).step(run.macro)
       );
     } while (


### PR DESCRIPTION
kevinzana (#591276) had an issue where garbo banished a gregged embezzler while trying to initialize the digitize counter, despite having already started it. Adding some wiggle room to the counters (extending into -3), as well as a macro that won't banish the embezzler.