### PR TITLE
Bonus drop items update

### DIFF
--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -355,7 +355,7 @@ function mafiaThumbRing(equipMode: BonusEquipMode) {
 
 function luckyGoldRing(equipMode: BonusEquipMode) {
   // Ignore for DMT, assuming mafia might get confused about the volcoino drop by the weird combats
-  if (!have($item`lucky gold ring`) || ["dmt"].some((mode) => mode === equipMode)) {
+  if (!have($item`lucky gold ring`) || equipMode === "dmt") {
     return new Map<Item, number>([]);
   }
 
@@ -398,7 +398,7 @@ function luckyGoldRing(equipMode: BonusEquipMode) {
   return new Map<Item, number>([
     [
       $item`lucky gold ring`,
-      dropValues.reduce((previous, current) => previous + current) / dropValues.length / 10,
+      sumNumbers(dropValues) / dropValues.length / 10,
     ],
   ]);
 }

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -354,7 +354,8 @@ function mafiaThumbRing(equipMode: BonusEquipMode) {
 }
 
 function luckyGoldRing(equipMode: BonusEquipMode) {
-  if (!have($item`lucky gold ring`)) {
+  // Ignore for DMT, assuming mafia might get confused about the volcoino drop by the weird combats
+  if (!have($item`lucky gold ring`) || ["dmt"].some((mode) => mode === equipMode)) {
     return new Map<Item, number>([]);
   }
 
@@ -402,7 +403,7 @@ function luckyGoldRing(equipMode: BonusEquipMode) {
   ]);
 }
 
-function mrCheengsSpectacles(equipMode: BonusEquipMode) {
+function mrCheengsSpectacles() {
   if (!have($item`Mr. Cheeng's spectacles`)) {
     return new Map<Item, number>([]);
   }
@@ -412,7 +413,7 @@ function mrCheengsSpectacles(equipMode: BonusEquipMode) {
   return new Map<Item, number>([[$item`Mr. Cheeng's spectacles`, 400]]);
 }
 
-function mrScreegesSpectacles(equipMode: BonusEquipMode) {
+function mrScreegesSpectacles() {
   if (!have($item`Mr. Screege's spectacles`)) {
     return new Map<Item, number>([]);
   }
@@ -421,7 +422,7 @@ function mrScreegesSpectacles(equipMode: BonusEquipMode) {
   return new Map<Item, number>([[$item`Mr. Screege's spectacles`, 180]]);
 }
 
-function pantogramPants(equipMode: BonusEquipMode) {
+function pantogramPants() {
   if (!have($item`pantogram pants`) || !get("_pantogramModifier").includes("Drops Items")) {
     return new Map<Item, number>([]);
   }
@@ -430,7 +431,7 @@ function pantogramPants(equipMode: BonusEquipMode) {
   return new Map<Item, number>([[$item`pantogram pants`, 100]]);
 }
 
-function bagOfManyConfections(equipMode: BonusEquipMode) {
+function bagOfManyConfections() {
   if (!have($item`bag of many confections`) || !have($familiar`Stocking Mimic`)) {
     return new Map<Item, number>([]);
   }
@@ -485,10 +486,10 @@ function dropsItems(equipMode: BonusEquipMode) {
   return new Map<Item, number>([
     ...mafiaThumbRing(equipMode),
     ...luckyGoldRing(equipMode),
-    ...mrCheengsSpectacles(equipMode),
-    ...mrScreegesSpectacles(equipMode),
-    ...pantogramPants(equipMode),
-    ...bagOfManyConfections(equipMode),
+    ...mrCheengsSpectacles(),
+    ...mrScreegesSpectacles(),
+    ...pantogramPants(),
+    ...bagOfManyConfections(),
     ...snowSuit(equipMode),
     ...mayflowerBouquet(equipMode),
   ]);

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -10,6 +10,7 @@ import {
   haveEffect,
   haveEquipped,
   inebrietyLimit,
+  itemAmount,
   mallPrice,
   myClass,
   myFamiliar,
@@ -323,6 +324,7 @@ function pantsgiving() {
   pantsgivingBonuses.set(turns, pantsgivingBonus);
   return new Map<Item, number>([[$item`Pantsgiving`, pantsgivingBonus]]);
 }
+
 const haveSomeCheese = getFoldGroup($item`stinky cheese diaper`).some((item) => have(item));
 function cheeses(embezzlerUp: boolean) {
   return haveSomeCheese &&
@@ -340,6 +342,107 @@ function cheeses(embezzlerUp: boolean) {
       )
     : [];
 }
+
+function mafiaThumbRing(equipMode: BonusEquipMode) {
+  if (!have($item`mafia thumb ring`) || ["free", "dmt"].some((mode) => mode === equipMode)) {
+    return new Map<Item, number>([]);
+  }
+
+  return new Map<Item, number>([
+    [$item`mafia thumb ring`, (1 / 0.96 - 1) * get("valueOfAdventure")],
+  ]);
+}
+
+function luckyGoldRing(equipMode: BonusEquipMode) {
+  if (!have($item`lucky gold ring`)) {
+    return new Map<Item, number>([]);
+  }
+
+  // Volcoino has a low drop rate which isn't accounted for here
+  // Overestimating until it drops is probably fine, don't @ me
+  const dropValues = [
+    100, // 80 - 120 meat
+    ...[
+      itemAmount($item`hobo nickel`) > 0 ? 100 : 0, // This should be closeted
+      itemAmount($item`sand dollar`) > 0 ? getSaleValue($item`sand dollar`) : 0, // This should be closeted
+      itemAmount($item`Freddy Kruegerand`) > 0
+        ? Math.max(
+            getSaleValue($item`bottle of Bloodweiser`) / 200,
+            getSaleValue($item`electric Kool-Aid`) / 200
+          )
+        : 0,
+      get("sleazeAirportAlways") || get("_sleazeAirportToday")
+        ? getSaleValue($item`one-day ticket to Spring Break Beach`) / 100
+        : 0,
+      get("spookyAirportAlways") || get("_spookyAirportToday")
+        ? getSaleValue($item`one-day ticket to Conspiracy Island`) / 100
+        : 0,
+      get("stenchAirportAlways") || get("_stenchAirportToday")
+        ? getSaleValue($item`one-day ticket to Dinseylandfill`) / 20
+        : 0,
+      !get("_luckyGoldRingVolcoino") && (get("hotAirportAlways") || get("_hotAirportToday"))
+        ? Math.max(
+            getSaleValue($item`one-day ticket to That 70s Volcano`) / 3,
+            getSaleValue($item`karma shawarma`) / 7
+          )
+        : 0,
+      get("coldAirportAlways") || get("_coldAirportToday")
+        ? getSaleValue($item`one-day ticket to The Glaciest`) / 50
+        : 0,
+      get("frAlways") || get("_frToday") ? getSaleValue($item`FantasyRealm guest pass`) / 350 : 0,
+    ].filter((value) => value > 0),
+  ];
+
+  // Items drop every ~10 turns
+  return new Map<Item, number>([
+    [
+      $item`lucky gold ring`,
+      dropValues.reduce((previous, current) => previous + current) / dropValues.length / 10,
+    ],
+  ]);
+}
+
+function mrCheengsSpectacles(equipMode: BonusEquipMode) {
+  if (!have($item`Mr. Cheeng's spectacles`)) {
+    return new Map<Item, number>([]);
+  }
+
+  // Items drop every 4 turns
+  // TODO: Possible drops are speculated to be any pvpable potion that will never be banned by standard
+  return new Map<Item, number>([[$item`Mr. Cheeng's spectacles`, 400]]);
+}
+
+function mrScreegesSpectacles(equipMode: BonusEquipMode) {
+  if (!have($item`Mr. Screege's spectacles`)) {
+    return new Map<Item, number>([]);
+  }
+
+  // TODO: Calculate actual bonus value (good luck!)
+  return new Map<Item, number>([[$item`Mr. Screege's spectacles`, 180]]);
+}
+
+function pantogramPants(equipMode: BonusEquipMode) {
+  if (!have($item`pantogram pants`) || !get("_pantogramModifier").includes("Drops Items")) {
+    return new Map<Item, number>([]);
+  }
+
+  // TODO: Calculate actual bonus value (good luck!)
+  return new Map<Item, number>([[$item`pantogram pants`, 100]]);
+}
+
+function bagOfManyConfections(equipMode: BonusEquipMode) {
+  if (!have($item`bag of many confections`)) {
+    return new Map<Item, number>([]);
+  }
+
+  return new Map<Item, number>([
+    [
+      $item`bag of many confections`,
+      getSaleValue(...$items`Polka Pop, BitterSweetTarts, Piddles`) / 6,
+    ],
+  ]);
+}
+
 function snowSuit(equipMode: BonusEquipMode) {
   // Ignore for EMBEZZLER
   // Ignore for DMT, assuming mafia might get confused about the drop by the weird combats
@@ -352,6 +455,7 @@ function snowSuit(equipMode: BonusEquipMode) {
 
   return new Map<Item, number>([[$item`Snow Suit`, getSaleValue($item`carrot nose`) / 10]]);
 }
+
 function mayflowerBouquet(equipMode: BonusEquipMode) {
   // +40% meat drop 12.5% of the time (effectively 5%)
   // Drops flowers 50% of the time, wiki says 5-10 a day.
@@ -376,18 +480,15 @@ function mayflowerBouquet(equipMode: BonusEquipMode) {
     ],
   ]);
 }
+
 function dropsItems(equipMode: BonusEquipMode) {
-  const isFree = ["free", "dmt"].some((mode) => mode === equipMode);
   return new Map<Item, number>([
-    [$item`mafia thumb ring`, !isFree ? 300 : 0],
-    [$item`lucky gold ring`, 400],
-    [$item`Mr. Cheeng's spectacles`, 250],
-    [$item`pantogram pants`, get("_pantogramModifier").includes("Drops Items") ? 100 : 0],
-    [$item`Mr. Screege's spectacles`, 180],
-    [
-      $item`bag of many confections`,
-      getSaleValue(...$items`Polka Pop, BitterSweetTarts, Piddles`) / 6,
-    ],
+    ...mafiaThumbRing(equipMode),
+    ...luckyGoldRing(equipMode),
+    ...mrCheengsSpectacles(equipMode),
+    ...mrScreegesSpectacles(equipMode),
+    ...pantogramPants(equipMode),
+    ...bagOfManyConfections(equipMode),
     ...snowSuit(equipMode),
     ...mayflowerBouquet(equipMode),
   ]);

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -375,16 +375,16 @@ function luckyGoldRing(equipMode: BonusEquipMode) {
         ? getSaleValue($item`one-day ticket to Spring Break Beach`) / 100
         : 0,
       get("spookyAirportAlways") || get("_spookyAirportToday")
-        ? getSaleValue($item`one-day ticket to Conspiracy Island`) / 100
+        ? Math.max(
+            getSaleValue($item`one-day ticket to Conspiracy Island`) / 100,
+            getSaleValue($item`karma shawarma`) / 7
+          )
         : 0,
       get("stenchAirportAlways") || get("_stenchAirportToday")
         ? getSaleValue($item`one-day ticket to Dinseylandfill`) / 20
         : 0,
-      !get("_luckyGoldRingVolcoino") && (get("hotAirportAlways") || get("_hotAirportToday"))
-        ? Math.max(
-            getSaleValue($item`one-day ticket to That 70s Volcano`) / 3,
-            getSaleValue($item`karma shawarma`) / 7
-          )
+      (get("hotAirportAlways") || get("_hotAirportToday")) && !get("_luckyGoldRingVolcoino")
+        ? getSaleValue($item`one-day ticket to That 70s Volcano`) / 3
         : 0,
       get("coldAirportAlways") || get("_coldAirportToday")
         ? getSaleValue($item`one-day ticket to The Glaciest`) / 50

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -39,6 +39,7 @@ import {
   have,
   maximizeCached,
   Requirement,
+  sumNumbers,
 } from "libram";
 import { pickBjorn, valueBjornModifiers } from "./bjorn";
 import { estimatedTurns } from "./embezzler";
@@ -369,7 +370,8 @@ function luckyGoldRing(equipMode: BonusEquipMode) {
       itemAmount($item`Freddy Kruegerand`) > 0
         ? Math.max(
             getSaleValue($item`bottle of Bloodweiser`) / 200,
-            getSaleValue($item`electric Kool-Aid`) / 200
+            getSaleValue($item`electric Kool-Aid`) / 200,
+            getSaleValue($item`Dreadsylvanian skeleton key`) / 25
           )
         : 0,
       get("sleazeAirportAlways") || get("_sleazeAirportToday")
@@ -396,10 +398,7 @@ function luckyGoldRing(equipMode: BonusEquipMode) {
 
   // Items drop every ~10 turns
   return new Map<Item, number>([
-    [
-      $item`lucky gold ring`,
-      sumNumbers(dropValues) / dropValues.length / 10,
-    ],
+    [$item`lucky gold ring`, sumNumbers(dropValues) / dropValues.length / 10],
   ]);
 }
 

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -431,7 +431,7 @@ function pantogramPants(equipMode: BonusEquipMode) {
 }
 
 function bagOfManyConfections(equipMode: BonusEquipMode) {
-  if (!have($item`bag of many confections`)) {
+  if (!have($item`bag of many confections`) || !have($familiar`Stocking Mimic`)) {
     return new Map<Item, number>([]);
   }
 


### PR DESCRIPTION
- mafia thumb ring based on valueOfAdventure
- lucky gold ring based on what currencies could drop (currently over estimated if the volcoino hasn't dropped yet). Uses day passes, karma shawarma, & good dread consumables for values. Hobo nickel is set at 100, but garbo already closets these so w/e
- Update Mr. Cheeng's spectacles to 400 based on discussion in discord. We speculate the drop items are any pvpable potion that will never be banned by standard restrictions, which seems to check out. Could be dynamically generated later if we can get the list of standard items for the current year
- Don't add bonuses to maximizer string if the equipment is unavailable