### PR TITLE
More mana burning

### DIFF
--- a/src/fights.ts
+++ b/src/fights.ts
@@ -23,7 +23,6 @@ import {
   myInebriety,
   myLevel,
   myMaxhp,
-  myMp,
   myPathId,
   numericModifier,
   outfit,

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -23,6 +23,7 @@ import {
   myInebriety,
   myLevel,
   myMaxhp,
+  myMp,
   myPathId,
   numericModifier,
   outfit,
@@ -172,21 +173,21 @@ function embezzlerSetup() {
   safeRestore();
   freeFightMood().execute(50);
   withStash($items`Platinum Yendorian Express Card, Bag o' Tricks`, () => {
-    maximize("MP", false);
     if (have($item`Platinum Yendorian Express Card`) && !get("expressCardUsed")) {
+      maximize("MP", false);
       burnLibrams();
       use($item`Platinum Yendorian Express Card`);
-      burnLibrams();
     }
     if (have($item`Bag o' Tricks`) && !get("_bagOTricksUsed")) {
       use($item`Bag o' Tricks`);
     }
   });
   if (have($item`License to Chill`) && !get("_licenseToChillUsed")) {
+    maximize("MP", false);
     burnLibrams();
     use($item`License to Chill`);
-    burnLibrams();
   }
+  burnLibrams(400);
   if (
     globalOptions.ascending &&
     questStep("questM16Temple") > 0 &&

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -176,6 +176,7 @@ function embezzlerSetup() {
     if (have($item`Platinum Yendorian Express Card`) && !get("expressCardUsed")) {
       burnLibrams();
       use($item`Platinum Yendorian Express Card`);
+      burnLibrams();
     }
     if (have($item`Bag o' Tricks`) && !get("_bagOTricksUsed")) {
       use($item`Bag o' Tricks`);
@@ -184,6 +185,7 @@ function embezzlerSetup() {
   if (have($item`License to Chill`) && !get("_licenseToChillUsed")) {
     burnLibrams();
     use($item`License to Chill`);
+    burnLibrams();
   }
   if (
     globalOptions.ascending &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -356,6 +356,9 @@ export function main(argString = ""): void {
       autoTuxedo: true,
       autoPinkyRing: true,
       autoGarish: true,
+      allowNonMoodBurning: !globalOptions.ascending,
+      allowSummonBurning: true,
+      libramSkillsSoftcore: "none", // Don't cast librams when mana burning, handled manually based on sale price
     });
     let bestHalloweiner = 0;
     if (haveInCampground($item`haunted doghouse`)) {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -483,13 +483,17 @@ export function pillkeeperOpportunityCost(): number {
 /**
  * Burns existing MP on the mall-optimal libram skill until unable to cast any more.
  */
-export function burnLibrams(): void {
+export function burnLibrams(mpTarget = 0): void {
   let libramToCast = bestLibramToCast();
-  while (libramToCast && mpCost(libramToCast) <= myMp()) {
+  while (libramToCast && mpCost(libramToCast) <= myMp() - mpTarget) {
     useSkill(libramToCast);
     libramToCast = bestLibramToCast();
   }
-  cliExecute("burn *");
+  if (mpTarget > 0) {
+    cliExecute(`burn -${mpTarget}`);
+  } else {
+    cliExecute("burn *");
+  }
 }
 
 export function safeRestore(): void {
@@ -505,4 +509,6 @@ export function safeRestore(): void {
       eat($item`magical sausage`);
     } else restoreMp(mpTarget);
   }
+
+  burnLibrams(mpTarget * 2); // Leave a mp buffer when burning
 }


### PR DESCRIPTION
- Burn mp again after using express card or license to chill
- Don't maximize mp unless pyec or license will be used
- Burn mp after restoring hp or mp, leaving a threshold of double the target restore, to use any extra mp after a large restore (like  from eating a sausage)
- Enable allowNonMoodBurning only if not ascending, as the extra turns would be wasted
- Enable summon burning if not set, but don't burn on libram summons as that is handled manually based on sale price