### PR TITLE
Diet tweaks - limit potions, cheapest food, gregarious counts

### DIFF
--- a/src/potions.ts
+++ b/src/potions.ts
@@ -12,7 +12,18 @@ import {
   print,
   use,
 } from "kolmafia";
-import { $effect, $effects, $familiar, $item, $items, get, getActiveEffects, have } from "libram";
+import {
+  $effect,
+  $effects,
+  $familiar,
+  $item,
+  $items,
+  clamp,
+  get,
+  getActiveEffects,
+  have,
+  sumNumbers,
+} from "libram";
 import { acquire } from "./acquire";
 import { baseMeat, globalOptions, pillkeeperOpportunityCost } from "./lib";
 import { embezzlerCount, estimatedTurns } from "./embezzler";
@@ -211,7 +222,7 @@ export class Potion {
     }[] = [];
     const limitFunction = limit
       ? (quantity: number) =>
-          Math.min(limit - values.reduce((total, tier) => total + tier.quantity, 0), quantity)
+          clamp(limit - sumNumbers(values.map((tier) => tier.quantity)), 0, quantity)
       : (quantity: number) => quantity;
 
     // compute the value of covering embezzlers

--- a/src/potions.ts
+++ b/src/potions.ts
@@ -211,7 +211,7 @@ export class Potion {
     }[] = [];
     const limitFunction = limit
       ? (quantity: number) =>
-          Math.min(limit - values.reduce((_total, tier) => tier.quantity, 0), quantity)
+          Math.min(limit - values.reduce((total, tier) => total + tier.quantity, 0), quantity)
       : (quantity: number) => quantity;
 
     // compute the value of covering embezzlers


### PR DESCRIPTION
* limit potions to once per day
* only consider the cheapest of items with the same adventure yield
* properly count existing gregarious charge