### PR TITLE
Don't use MP restores every fight.

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -341,11 +341,15 @@ export function burnLibrams(mpTarget = 0): void {
   }
 }
 
+export function safeRestoreMpTarget(): number {
+  return Math.min(myMaxmp(), 200);
+}
+
 export function safeRestore(): void {
   if (myHp() < myMaxhp() * 0.5) {
     restoreHp(myMaxhp() * 0.9);
   }
-  const mpTarget = Math.min(myMaxmp(), 200);
+  const mpTarget = safeRestoreMpTarget();
   if (myMp() < mpTarget) {
     if (
       (have($item`magical sausage`) || have($item`magical sausage casing`)) &&

--- a/src/mood.ts
+++ b/src/mood.ts
@@ -32,7 +32,7 @@ import {
   uneffect,
   Witchess,
 } from "libram";
-import { baseMeat, questStep, setChoice } from "./lib";
+import { baseMeat, questStep, safeRestoreMpTarget, setChoice } from "./lib";
 import { estimatedTurns } from "./embezzler";
 import { withStash } from "./clan";
 import synthesize from "./synthesis";
@@ -47,7 +47,8 @@ Mood.setDefaultOptions({
 });
 
 export function meatMood(urKels = false): Mood {
-  const mood = new Mood();
+  // Reserve the amount of MP we try to restore before each fight.
+  const mood = new Mood({ reserveMp: safeRestoreMpTarget() });
 
   mood.potion($item`How to Avoid Scams`, 3 * baseMeat);
   mood.potion($item`resolution: be wealthier`, 0.3 * baseMeat);


### PR DESCRIPTION
Reserve the MP we're about to restore before each fight when casting our mood. That way we're not constantly using MP restores to get more turns of Pasta Eyeball.