### PR TITLE
stop running into issues with void monsters during drunk pygmies

### DIFF
--- a/src/dropsgear.ts
+++ b/src/dropsgear.ts
@@ -309,7 +309,11 @@ function bonusAccessories(equipMode: BonusEquipMode): Map<Item, number> {
 }
 
 export function magnifyingGlass(): Map<Item, number> {
-  if (!have($item`cursed magnifying glass`) || get("_voidFreeFights") >= 5) {
+  if (
+    !have($item`cursed magnifying glass`) ||
+    get("_voidFreeFights") >= 5 ||
+    get("cursedMagnifyingGlassCount") >= 13
+  ) {
     return new Map<Item, number>();
   }
 

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -1951,9 +1951,10 @@ function voidMonster(): void {
   ) {
     return;
   }
-
-  useFamiliar(freeFightFamiliar());
-  freeFightOutfit(new Requirement([], { forceEquip: $items`cursed magnifying glass` }));
-  adventureMacro(determineDraggableZoneAndEnsureAccess(), Macro.basicCombat());
-  postCombatActions();
+  do {
+    useFamiliar(freeFightFamiliar());
+    freeFightOutfit(new Requirement([], { forceEquip: $items`cursed magnifying glass` }));
+    adventureMacro(determineDraggableZoneAndEnsureAccess(), Macro.basicCombat());
+    postCombatActions();
+  } while (!get("lastEncounter").includes("void"));
 }

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -1951,10 +1951,9 @@ function voidMonster(): void {
   ) {
     return;
   }
-  do {
-    useFamiliar(freeFightFamiliar());
-    freeFightOutfit(new Requirement([], { forceEquip: $items`cursed magnifying glass` }));
-    adventureMacro(determineDraggableZoneAndEnsureAccess(), Macro.basicCombat());
-    postCombatActions();
-  } while (!get("lastEncounter").includes("void"));
+
+  useFamiliar(freeFightFamiliar());
+  freeFightOutfit(new Requirement([], { forceEquip: $items`cursed magnifying glass` }));
+  adventureMacro(determineDraggableZoneAndEnsureAccess(), Macro.basicCombat());
+  postCombatActions();
 }


### PR DESCRIPTION
Right now, if determineDraggable...() sends us to zones with free intro adventures, we will fail to fight a void monster, and then get a void monster in the middle of drunk pygmies.

Instead, we don't do that.