### PR TITLE
meat stasis rework

### DIFF
--- a/src/combat.ts
+++ b/src/combat.ts
@@ -332,7 +332,7 @@ export class Macro extends StrictMacro {
     const hpCheck = checkPassive
       ? `!hppercentbelow 25 && monsterhpabove ${passiveDamage}`
       : "!hppercentbelow 25";
-    // Same story but for the gun
+    // Same story but for the sixgun shot, which wants 40 more HP if possible
     const hpCheckSixgun = checkPassive
       ? `!hppercentbelow 25 && monsterhpabove ${passiveDamage + 40}`
       : "!hppercentbelow 25";
@@ -371,7 +371,7 @@ export class Macro extends StrictMacro {
         .if_(`${hpCheck}`, Macro.trySkill($skill`Extract`))
         .if_(`${hpCheck}`, Macro.tryHaveSkill($skill`Become a Wolf`))
         .if_(`${hpCheckSixgun}`, Macro.tryHaveItem($item`porquoise-handled sixgun`))
-        .while_(`${hpCheckSixgun} && !pastround ${stasisRounds}`, Macro.item(stasisItem))
+        .while_(`${hpCheck} && !pastround ${stasisRounds}`, Macro.item(stasisItem))
     );
   }
 

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -322,15 +322,14 @@ export class Macro extends StrictMacro {
       stasisItem = $item`facsimile dictionary`;
     } else if (retrieveItem($item`dictionary`)) {
       stasisItem = $item`dictionary`;
-    };
+    }
 
     // Construct the monster HP component of the stasis condition
     // Evaluate the passive damage
-    const passiveDamage =
-      maxPassiveDamage() + 5;
+    const passiveDamage = maxPassiveDamage() + 5;
     // Are we aiming to crit? If so, we need to respect the passive damage
-    const monsterHpCheck = (checkPassive) ? `&& monsterhpabove ${passiveDamage}` : '';
-    
+    const monsterHpCheck = checkPassive ? `&& monsterhpabove ${passiveDamage}` : "";
+
     // Determine how long we'll be stasising for
     // By default there's no reason to stasis
     let stasisRounds = 0;

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -309,6 +309,11 @@ export class Macro extends StrictMacro {
   }
 
   meatStasis(checkPassive: boolean): Macro {
+    // We can't stasis without manuel's monsterhpabove if we want to crit
+    if (checkPassive && !monsterManuelAvailable()) {
+      return this;
+    }
+
     // Determine stasis item to use
     // Garbo already gets a seal tooth at the start of the day, so that's around always
     let stasisItem = $item`seal tooth`;
@@ -323,10 +328,6 @@ export class Macro extends StrictMacro {
     // Evaluate the passive damage
     const passiveDamage =
       maxPassiveDamage() + 5;
-    // We can't stasis without manuel's monsterhpabove if we want to crit
-    if (checkPassive && !monsterManuelAvailable()) {
-      return this;
-    }
     // Are we aiming to crit? If so, we need to respect the passive damage
     const monsterHpCheck = (checkPassive) ? `&& monsterhpabove ${passiveDamage}` : '';
     

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -320,22 +320,15 @@ export class Macro extends StrictMacro {
     };
 
     // Construct the monster HP component of the stasis condition
-    // Start by evaluating the passive damage
+    // Evaluate the passive damage
     const passiveDamage =
       maxPassiveDamage() + 5;
-    // If we don't care about killing the monster don't bother checking passive damage
-    let monsterHpCheck = '';
-    // However, if we do care about killing the monster...
-    if (checkPassive) {
-      if (!monsterManuelAvailable()) {
-        // Only stasis if the monster manuel is available and we have access to monsterhpabove
-        return this;
-      } else {
-        // We're going to be stasising until we hit passiveDamage HP remaining
-        // Add the && part so it can be added at the end of the while clause easily
-        monsterHpCheck = `&& monsterhpabove ${passiveDamage}`;
-      }
+    // We can't stasis without manuel's monsterhpabove if we want to crit
+    if (checkPassive && !monsterManuelAvailable()) {
+      return this;
     }
+    // Are we aiming to crit? If so, we need to respect the passive damage
+    const monsterHpCheck = (checkPassive) ? `&& monsterhpabove ${passiveDamage}` : '';
     
     // Determine how long we'll be stasising for
     // By default there's no reason to stasis

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -355,9 +355,18 @@ export class Macro extends StrictMacro {
     }
 
     // Ignore unexpected monsters, holiday scaling monsters seem to abort with monsterhpabove
+    // Delevel the sausage goblins as otherwise they can kind of hurt
     return this.if_(
       "monstername angry tourist || monstername garbage tourist || monstername horrible tourist family || monstername Knob Goblin Embezzler || monstername sausage goblin",
-      Macro.if_(`monsterhpabove ${passiveDamage}`, Macro.trySkill($skill`Pocket Crumbs`))
+      Macro.if_(
+        `monsterhpabove ${passiveDamage} && monstername sausage goblin`,
+        Macro.tryHaveItem($item`Time-Spinner`)
+      )
+        .if_(
+          `monsterhpabove ${passiveDamage} && monstername sausage goblin`,
+          Macro.tryHaveSkill($skill`Micrometeorite`)
+        )
+        .if_(`monsterhpabove ${passiveDamage}`, Macro.trySkill($skill`Pocket Crumbs`))
         .if_(`monsterhpabove ${passiveDamage}`, Macro.trySkill($skill`Extract`))
         .if_(`monsterhpabove ${passiveDamage}`, Macro.tryHaveSkill($skill`Become a Wolf`))
         .if_(
@@ -422,7 +431,7 @@ export class Macro extends StrictMacro {
         .tryHaveSkill($skill`Become a Wolf`)
         .externalIf(
           !(myClass() === $class`Sauceror` && have($skill`Curse of Weaksauce`)),
-          Macro.while_("!pastround 20 && !hppercentbelow 25 && !missed 1", Macro.attack())
+          Macro.while_("!pastround 24 && !hppercentbelow 25 && !missed 1", Macro.attack())
         )
         // Using while_ here in case you run out of mp
         .while_("hasskill Saucegeyser", Macro.skill($skill`Saucegeyser`))

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -328,7 +328,14 @@ export class Macro extends StrictMacro {
     // Evaluate the passive damage
     const passiveDamage = maxPassiveDamage() + 5;
     // Are we aiming to crit? If so, we need to respect the passive damage
-    const monsterHpCheck = checkPassive ? `&& monsterhpabove ${passiveDamage}` : "";
+    // Also we need to respect our health total
+    const hpCheck = checkPassive
+      ? `!hppercentbelow 25 && monsterhpabove ${passiveDamage}`
+      : "!hppercentbelow 25";
+    // Same story but for the gun
+    const hpCheckSixgun = checkPassive
+      ? `!hppercentbelow 25 && monsterhpabove ${passiveDamage + 40}`
+      : "!hppercentbelow 25";
 
     // Determine how long we'll be stasising for
     // By default there's no reason to stasis
@@ -358,25 +365,13 @@ export class Macro extends StrictMacro {
     // Delevel the sausage goblins as otherwise they can kind of hurt
     return this.if_(
       "monstername angry tourist || monstername garbage tourist || monstername horrible tourist family || monstername Knob Goblin Embezzler || monstername sausage goblin",
-      Macro.if_(
-        `monsterhpabove ${passiveDamage} && monstername sausage goblin`,
-        Macro.tryHaveItem($item`Time-Spinner`)
-      )
-        .if_(
-          `monsterhpabove ${passiveDamage} && monstername sausage goblin`,
-          Macro.tryHaveSkill($skill`Micrometeorite`)
-        )
-        .if_(`monsterhpabove ${passiveDamage}`, Macro.trySkill($skill`Pocket Crumbs`))
-        .if_(`monsterhpabove ${passiveDamage}`, Macro.trySkill($skill`Extract`))
-        .if_(`monsterhpabove ${passiveDamage}`, Macro.tryHaveSkill($skill`Become a Wolf`))
-        .if_(
-          `monsterhpabove ${passiveDamage + 40}`,
-          Macro.tryHaveItem($item`porquoise-handled sixgun`)
-        )
-        .while_(
-          `!hppercentbelow 25 && !pastround ${stasisRounds} ${monsterHpCheck}`,
-          Macro.item(stasisItem)
-        )
+      Macro.if_(`${hpCheck} && monstername sausage goblin`, Macro.tryHaveItem($item`Time-Spinner`))
+        .if_(`${hpCheck} && monstername sausage goblin`, Macro.tryHaveSkill($skill`Micrometeorite`))
+        .if_(`${hpCheck}`, Macro.trySkill($skill`Pocket Crumbs`))
+        .if_(`${hpCheck}`, Macro.trySkill($skill`Extract`))
+        .if_(`${hpCheck}`, Macro.tryHaveSkill($skill`Become a Wolf`))
+        .if_(`${hpCheckSixgun}`, Macro.tryHaveItem($item`porquoise-handled sixgun`))
+        .while_(`${hpCheckSixgun} && !pastround ${stasisRounds}`, Macro.item(stasisItem))
     );
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -953,6 +953,14 @@
     "@babel/helper-validator-option" "^7.14.5"
     "@babel/plugin-transform-typescript" "^7.16.0"
 
+"@babel/runtime-corejs3@^7.14.9":
+  version "7.16.8"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.16.8.tgz#ea533d96eda6fdc76b1812248e9fbd0c11d4a1a7"
+  integrity sha512-3fKhuICS1lMz0plI5ktOE/yEtBRMVxplzRkdn6mJQ197XiY0JnrzYV0+Mxozq3JZ8SBV9Ecurmw1XsGbwOf+Sg==
+  dependencies:
+    core-js-pure "^3.20.2"
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.8.4":
   version "7.16.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.3.tgz#b86f0db02a04187a3c17caa77de69840165d42d5"
@@ -1848,6 +1856,16 @@ core-js-compat@^3.18.0, core-js-compat@^3.19.1:
   dependencies:
     browserslist "^4.17.6"
     semver "7.0.0"
+
+core-js-pure@^3.20.2:
+  version "3.21.0"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.21.0.tgz#819adc8dfb808205ce25b51d50591becd615db7e"
+  integrity sha512-VaJUunCZLnxuDbo1rNOzwbet9E1K9joiXS5+DQMPtgxd24wfsZbJZMMfQLGYMlCUvSxLfsRUUhoOR2x28mFfeg==
+
+core-js@3.15.2:
+  version "3.15.2"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.15.2.tgz#740660d2ff55ef34ce664d7e2455119c5bdd3d61"
+  integrity sha512-tKs41J7NJVuaya8DxIOCnl8QuPHx5/ZVbFo1oKgVl1qHFBBrDctzQGtuLjPpRdNTWmKPH6oEvgN/MUID+l485Q==
 
 core-js@^3.8.0:
   version "3.19.1"
@@ -2972,7 +2990,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash@^4.0.0, lodash@^4.17.15, lodash@~4.17.10:
+lodash@^4.0.0, lodash@^4.17.15, lodash@^4.17.21, lodash@~4.17.10:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
Summary of changes:
 - permit longer stasis if waiting for bittycar, hobo monkey or bjorn - I've seen them sometimes happen quite late in fights when I went to look at my pre-garbo logs
 - use a dictionary over a seal tooth for stasis if possible
 - throw OPS ahead of stasis to avoid double round awkwardness
 - redo the stasis code to have a single macro, with variables controlling the round count and whether to care about the monster HP
 - move the porquoise gun ahead of the stasis loop due to HP requirement awkwardness

Known issue in need of addressing:
 - `.kill()` would require a mild adjustment to deal with the longer stasis