### PR TITLE
Use-semicolons

### DIFF
--- a/src/combat.ts
+++ b/src/combat.ts
@@ -152,7 +152,7 @@ export function shouldRedigitize(): boolean {
 
 export class Macro extends StrictMacro {
   submit(): string {
-    print(this.components.join("\n"));
+    print(this.components.join(";"));
     return super.submit();
   }
 


### PR DESCRIPTION
Right now, when macros are printed to the CLI (and thus the session log), the whitespace is omitted, rendering them very hard to read and parse. This PR uses semicolons to join rather than linebreaks, which will actually appear on the CLI.