### PR TITLE
support for unsupported character states

### DIFF
--- a/src/embezzler.ts
+++ b/src/embezzler.ts
@@ -14,6 +14,7 @@ import {
   myFamiliar,
   myHash,
   myInebriety,
+  myLevel,
   myTurncount,
   print,
   retrieveItem,
@@ -190,6 +191,7 @@ export class EmbezzlerFight {
 function checkUnderwater() {
   // first check to see if underwater even makes sense
   if (
+    myLevel() >= 11 &&
     !(get("_envyfishEggUsed") || have($item`envyfish egg`)) &&
     (booleanModifier("Adventure Underwater") || waterBreathingEquipment.some(have)) &&
     (booleanModifier("Underwater Familiar") || familiarWaterBreathingEquipment.some(have)) &&

--- a/src/embezzler.ts
+++ b/src/embezzler.ts
@@ -193,8 +193,10 @@ function checkUnderwater() {
   if (
     myLevel() >= 11 &&
     !(get("_envyfishEggUsed") || have($item`envyfish egg`)) &&
-    (booleanModifier("Adventure Underwater") || waterBreathingEquipment.some((item) => have(item))) &&
-    (booleanModifier("Underwater Familiar") || familiarWaterBreathingEquipment.some((item) => have(item))) &&
+    (booleanModifier("Adventure Underwater") ||
+      waterBreathingEquipment.some((item) => have(item))) &&
+    (booleanModifier("Underwater Familiar") ||
+      familiarWaterBreathingEquipment.some((item) => have(item))) &&
     (have($effect`Fishy`) || (have($item`fishy pipe`) && !get("_fishyPipeUsed")))
   ) {
     // then check if the underwater copy makes sense

--- a/src/embezzler.ts
+++ b/src/embezzler.ts
@@ -193,8 +193,8 @@ function checkUnderwater() {
   if (
     myLevel() >= 11 &&
     !(get("_envyfishEggUsed") || have($item`envyfish egg`)) &&
-    (booleanModifier("Adventure Underwater") || waterBreathingEquipment.some(have)) &&
-    (booleanModifier("Underwater Familiar") || familiarWaterBreathingEquipment.some(have)) &&
+    (booleanModifier("Adventure Underwater") || waterBreathingEquipment.some((item) => have(item))) &&
+    (booleanModifier("Underwater Familiar") || familiarWaterBreathingEquipment.some((item) => have(item))) &&
     (have($effect`Fishy`) || (have($item`fishy pipe`) && !get("_fishyPipeUsed")))
   ) {
     // then check if the underwater copy makes sense

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -412,6 +412,8 @@ export function dailyFights(): void {
         }
       }
 
+      useFamiliar(meatFamiliar());
+
       // REMAINING EMBEZZLER FIGHTS
       let nextFight = getNextEmbezzlerFight();
       while (nextFight !== null) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,8 +173,10 @@ function barfTurn() {
     useFamiliar(meatFamiliar());
     const location = embezzlerUp
       ? !get("_envyfishEggUsed") &&
-        (booleanModifier("Adventure Underwater") || waterBreathingEquipment.some(have)) &&
-        (booleanModifier("Underwater Familiar") || familiarWaterBreathingEquipment.some(have)) &&
+        (booleanModifier("Adventure Underwater") ||
+          waterBreathingEquipment.some((item) => have(item))) &&
+        (booleanModifier("Underwater Familiar") ||
+          familiarWaterBreathingEquipment.some((item) => have(item))) &&
         (have($effect`Fishy`) || (have($item`fishy pipe`) && !get("_fishyPipeUsed"))) &&
         !have($item`envyfish egg`)
         ? $location`The Briny Deeps`

--- a/src/index.ts
+++ b/src/index.ts
@@ -280,7 +280,7 @@ export function main(argString = ""): void {
 
   if (!get("garbo_skipAscensionCheck", false) && (!get("kingLiberated") || myLevel() < 13)) {
     const proceedRegardless = userConfirm(
-      "Looks like your ascension may not be done yet. Are you sure you want to garbo?"
+      "Looks like your ascension may not be done yet. Running garbo in an unintended character state can result in serious injury and even death. Are you sure you want to garbologize?"
     );
     if (!proceedRegardless) {
       throw new Error("User interrupt requested. Stopping Garbage Collector.");

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,6 +173,7 @@ function barfTurn() {
     useFamiliar(meatFamiliar());
     const location = embezzlerUp
       ? !get("_envyfishEggUsed") &&
+        myLevel() >= 11 &&
         (booleanModifier("Adventure Underwater") ||
           waterBreathingEquipment.some((item) => have(item))) &&
         (booleanModifier("Underwater Familiar") ||


### PR DESCRIPTION
bit of an omnibus PR:
 - Makes messaging for unprepared characters more dramatic
 - Fixes issue with talking to the Old Man when underleveled
 - Removes the use of `.some(have)` for items (because that always returns true; it's fine for familiars and skills)
 - Fixes non-destructive but recurring issue where garbo attempts to do the romance arrow in the sea by switching to meat familiar after completing profchain
