### PR TITLE
add auto confirmation handling

### DIFF
--- a/mafia/data/garbo_settings.json
+++ b/mafia/data/garbo_settings.json
@@ -35,5 +35,10 @@
     "name": "garbo_skipPillCheck",
     "type": "boolean",
     "description": "Should skip prompting you to go acquire distention and synthetic dog hair pills? Set to true if you want to proceed without them, and false if you want to be reminded."
+  },
+  {
+    "name": "garbo_autoUserConfirm",
+    "type": "boolean",
+    "description": "**WARNING: Experimental** Don't show user confirm dialogs, instead automatically select yes/no in a way that will allow garbo to continue executing. Useful for scripting/headless. Risky and potentially destructive."
   }
 ]

--- a/src/clan.ts
+++ b/src/clan.ts
@@ -18,7 +18,7 @@ import {
 } from "kolmafia";
 import { $familiar, $item, $items, $monster, Clan, get, getFoldGroup, have, set } from "libram";
 import { Macro } from "./combat";
-import { userConfirmDialog, HIGHLIGHT } from "./lib";
+import { HIGHLIGHT, userConfirmDialog } from "./lib";
 
 export const stashItems = get("garboStashItems", "")
   .split(",")

--- a/src/clan.ts
+++ b/src/clan.ts
@@ -14,12 +14,11 @@ import {
   stashAmount,
   takeStash,
   toItem,
-  userConfirm,
   visitUrl,
 } from "kolmafia";
 import { $familiar, $item, $items, $monster, Clan, get, getFoldGroup, have, set } from "libram";
 import { Macro } from "./combat";
-import { HIGHLIGHT } from "./lib";
+import { customUserConfirm, HIGHLIGHT } from "./lib";
 
 export const stashItems = get("garboStashItems", "")
   .split(",")
@@ -43,10 +42,10 @@ export function withVIPClan<T>(action: () => T): T {
     : clanIdOrNameString;
   if (clanIdOrName === "" && have($item`Clan VIP Lounge key`)) {
     if (
-      userConfirm(
+      customUserConfirm(
         "The preference 'garbo_vipClan' is not set. Use the current clan as a VIP clan? (Defaults to yes in 15 seconds)",
-        15000,
-        true
+        true,
+        15000
       )
     ) {
       clanIdOrName = getClanId();

--- a/src/clan.ts
+++ b/src/clan.ts
@@ -18,7 +18,7 @@ import {
 } from "kolmafia";
 import { $familiar, $item, $items, $monster, Clan, get, getFoldGroup, have, set } from "libram";
 import { Macro } from "./combat";
-import { customUserConfirm, HIGHLIGHT } from "./lib";
+import { userConfirmDialog, HIGHLIGHT } from "./lib";
 
 export const stashItems = get("garboStashItems", "")
   .split(",")
@@ -42,7 +42,7 @@ export function withVIPClan<T>(action: () => T): T {
     : clanIdOrNameString;
   if (clanIdOrName === "" && have($item`Clan VIP Lounge key`)) {
     if (
-      customUserConfirm(
+      userConfirmDialog(
         "The preference 'garbo_vipClan' is not set. Use the current clan as a VIP clan? (Defaults to yes in 15 seconds)",
         true,
         15000

--- a/src/diet.ts
+++ b/src/diet.ts
@@ -64,7 +64,7 @@ import { expectedGregs } from "./extrovermectin";
 import {
   argmax,
   arrayEquals,
-  customUserConfirm,
+  userConfirmDialog,
   globalOptions,
   HIGHLIGHT,
   realmAvailable,
@@ -234,7 +234,7 @@ function pillCheck(): void {
     if (!get("garbo_skipPillCheck", false) && !have($item`distention pill`, 1)) {
       set(
         "garbo_skipPillCheck",
-        customUserConfirm(
+        userConfirmDialog(
           "You do not have any distention pills. Continue anyway? (Defaulting to no in 15 seconds)",
           false,
           15000
@@ -247,7 +247,7 @@ function pillCheck(): void {
     if (!get("garbo_skipPillCheck", false) && !have($item`synthetic dog hair pill`, 1)) {
       set(
         "garbo_skipPillCheck",
-        customUserConfirm(
+        userConfirmDialog(
           "You do not have any synthetic dog hair pills. Continue anyway? (Defaulting to no in 15 seconds)",
           false,
           15000

--- a/src/diet.ts
+++ b/src/diet.ts
@@ -31,7 +31,6 @@ import {
   turnsPerCast,
   use,
   useFamiliar,
-  userConfirm,
   useSkill,
   wait,
 } from "kolmafia";
@@ -62,7 +61,14 @@ import { acquire } from "./acquire";
 import { withVIPClan } from "./clan";
 import { embezzlerCount, estimatedTurns } from "./embezzler";
 import { expectedGregs } from "./extrovermectin";
-import { argmax, arrayEquals, globalOptions, HIGHLIGHT, realmAvailable } from "./lib";
+import {
+  argmax,
+  arrayEquals,
+  customUserConfirm,
+  globalOptions,
+  HIGHLIGHT,
+  realmAvailable,
+} from "./lib";
 import { Potion, PotionTier } from "./potions";
 import { garboValue } from "./session";
 import synthesize from "./synthesis";
@@ -228,10 +234,10 @@ function pillCheck(): void {
     if (!get("garbo_skipPillCheck", false) && !have($item`distention pill`, 1)) {
       set(
         "garbo_skipPillCheck",
-        userConfirm(
+        customUserConfirm(
           "You do not have any distention pills. Continue anyway? (Defaulting to no in 15 seconds)",
-          15000,
-          false
+          false,
+          15000
         )
       );
     }
@@ -241,10 +247,10 @@ function pillCheck(): void {
     if (!get("garbo_skipPillCheck", false) && !have($item`synthetic dog hair pill`, 1)) {
       set(
         "garbo_skipPillCheck",
-        userConfirm(
+        customUserConfirm(
           "You do not have any synthetic dog hair pills. Continue anyway? (Defaulting to no in 15 seconds)",
-          15000,
-          false
+          false,
+          15000
         )
       );
     }

--- a/src/diet.ts
+++ b/src/diet.ts
@@ -64,10 +64,10 @@ import { expectedGregs } from "./extrovermectin";
 import {
   argmax,
   arrayEquals,
-  userConfirmDialog,
   globalOptions,
   HIGHLIGHT,
   realmAvailable,
+  userConfirmDialog,
 } from "./lib";
 import { Potion, PotionTier } from "./potions";
 import { garboValue } from "./session";

--- a/src/embezzler.ts
+++ b/src/embezzler.ts
@@ -54,11 +54,11 @@ import { usingThumbRing } from "./dropsgear";
 import { crateStrategy, equipOrbIfDesired } from "./extrovermectin";
 import {
   averageEmbezzlerNet,
-  userConfirmDialog,
   globalOptions,
   HIGHLIGHT,
   ltbRun,
   setChoice,
+  userConfirmDialog,
   WISH_VALUE,
 } from "./lib";
 import { familiarWaterBreathingEquipment, waterBreathingEquipment } from "./outfit";

--- a/src/embezzler.ts
+++ b/src/embezzler.ts
@@ -24,7 +24,6 @@ import {
   toMonster,
   toUrl,
   use,
-  userConfirm,
   visitUrl,
   wait,
 } from "kolmafia";
@@ -55,6 +54,7 @@ import { usingThumbRing } from "./dropsgear";
 import { crateStrategy, equipOrbIfDesired } from "./extrovermectin";
 import {
   averageEmbezzlerNet,
+  customUserConfirm,
   globalOptions,
   HIGHLIGHT,
   ltbRun,
@@ -729,8 +729,9 @@ export const embezzlerSources = [
         .map((source) => `${source.potential()} from ${source.name}`)
         .forEach((text) => print(text, HIGHLIGHT));
       globalOptions.askedAboutWish = true;
-      globalOptions.wishAnswer = userConfirm(
-        `Garbo has detected you have ${potential} potential ways to copy an Embezzler, but no way to start a fight with one. Current embezzler net (before potions) is ${averageEmbezzlerNet()}, so we expect to earn ${profit} meat, after the cost of a 11-leaf clover. Should we get Lucky! for an Embezzler?`
+      globalOptions.wishAnswer = customUserConfirm(
+        `Garbo has detected you have ${potential} potential ways to copy an Embezzler, but no way to start a fight with one. Current embezzler net (before potions) is ${averageEmbezzlerNet()}, so we expect to earn ${profit} meat, after the cost of a 11-leaf clover. Should we get Lucky! for an Embezzler?`,
+        true
       );
       return globalOptions.wishAnswer;
     },
@@ -761,8 +762,9 @@ export const embezzlerSources = [
         .map((source) => `${source.potential()} from ${source.name}`)
         .forEach((text) => print(text, HIGHLIGHT));
       globalOptions.askedAboutWish = true;
-      globalOptions.wishAnswer = userConfirm(
-        `Garbo has detected you have ${potential} potential ways to copy an Embezzler, but no way to start a fight with one. Current embezzler net (before potions) is ${averageEmbezzlerNet()}, so we expect to earn ${profit} meat, after the cost of a wish. Should we wish for an Embezzler?`
+      globalOptions.wishAnswer = customUserConfirm(
+        `Garbo has detected you have ${potential} potential ways to copy an Embezzler, but no way to start a fight with one. Current embezzler net (before potions) is ${averageEmbezzlerNet()}, so we expect to earn ${profit} meat, after the cost of a wish. Should we wish for an Embezzler?`,
+        true
       );
       return globalOptions.wishAnswer;
     },

--- a/src/embezzler.ts
+++ b/src/embezzler.ts
@@ -54,7 +54,7 @@ import { usingThumbRing } from "./dropsgear";
 import { crateStrategy, equipOrbIfDesired } from "./extrovermectin";
 import {
   averageEmbezzlerNet,
-  customUserConfirm,
+  userConfirmDialog,
   globalOptions,
   HIGHLIGHT,
   ltbRun,
@@ -729,7 +729,7 @@ export const embezzlerSources = [
         .map((source) => `${source.potential()} from ${source.name}`)
         .forEach((text) => print(text, HIGHLIGHT));
       globalOptions.askedAboutWish = true;
-      globalOptions.wishAnswer = customUserConfirm(
+      globalOptions.wishAnswer = userConfirmDialog(
         `Garbo has detected you have ${potential} potential ways to copy an Embezzler, but no way to start a fight with one. Current embezzler net (before potions) is ${averageEmbezzlerNet()}, so we expect to earn ${profit} meat, after the cost of a 11-leaf clover. Should we get Lucky! for an Embezzler?`,
         true
       );
@@ -762,7 +762,7 @@ export const embezzlerSources = [
         .map((source) => `${source.potential()} from ${source.name}`)
         .forEach((text) => print(text, HIGHLIGHT));
       globalOptions.askedAboutWish = true;
-      globalOptions.wishAnswer = customUserConfirm(
+      globalOptions.wishAnswer = userConfirmDialog(
         `Garbo has detected you have ${potential} potential ways to copy an Embezzler, but no way to start a fight with one. Current embezzler net (before potions) is ${averageEmbezzlerNet()}, so we expect to earn ${profit} meat, after the cost of a wish. Should we wish for an Embezzler?`,
         true
       );

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,6 @@ import { freeFightFamiliar, meatFamiliar } from "./familiar";
 import { dailyFights, freeFights, printEmbezzlerLog } from "./fights";
 import {
   checkGithubVersion,
-  userConfirmDialog,
   embezzlerLog,
   globalOptions,
   HIGHLIGHT,
@@ -73,6 +72,7 @@ import {
   questStep,
   safeRestore,
   setChoice,
+  userConfirmDialog,
 } from "./lib";
 import { meatMood } from "./mood";
 import postCombatActions from "./post";

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,6 @@ import {
   totalTurnsPlayed,
   use,
   useFamiliar,
-  userConfirm,
   visitUrl,
   xpath,
 } from "kolmafia";
@@ -63,6 +62,7 @@ import { freeFightFamiliar, meatFamiliar } from "./familiar";
 import { dailyFights, freeFights, printEmbezzlerLog } from "./fights";
 import {
   checkGithubVersion,
+  customUserConfirm,
   embezzlerLog,
   globalOptions,
   HIGHLIGHT,
@@ -282,8 +282,9 @@ export function main(argString = ""): void {
   }
 
   if (!get("garbo_skipAscensionCheck", false) && (!get("kingLiberated") || myLevel() < 13)) {
-    const proceedRegardless = userConfirm(
-      "Looks like your ascension may not be done yet. Running garbo in an unintended character state can result in serious injury and even death. Are you sure you want to garbologize?"
+    const proceedRegardless = customUserConfirm(
+      "Looks like your ascension may not be done yet. Running garbo in an unintended character state can result in serious injury and even death. Are you sure you want to garbologize?",
+      true
     );
     if (!proceedRegardless) {
       throw new Error("User interrupt requested. Stopping Garbage Collector.");
@@ -332,10 +333,11 @@ export function main(argString = ""): void {
 
   if (stashItems.length > 0) {
     if (
-      userConfirm(
+      customUserConfirm(
         `Garbo has detected that you have the following items still out of the stash from a previous run of garbo: ${stashItems
           .map((item) => item.name)
-          .join(",")}. Would you like us to return these to the stash now?`
+          .join(",")}. Would you like us to return these to the stash now?`,
+        true
       )
     ) {
       const clanIdOrName = get("garbo_stashClan", "none");
@@ -541,7 +543,7 @@ export function main(argString = ""): void {
               availableAmount($item`FunFunds™`) >= 20 &&
               !have($item`one-day ticket to Dinseylandfill`)
             ) {
-              print("Buying a one-day tickets", HIGHLIGHT);
+              print("Buying a one-day ticket", HIGHLIGHT);
               buy(
                 $coinmaster`The Dinsey Company Store`,
                 1,

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ import { freeFightFamiliar, meatFamiliar } from "./familiar";
 import { dailyFights, freeFights, printEmbezzlerLog } from "./fights";
 import {
   checkGithubVersion,
-  customUserConfirm,
+  userConfirmDialog,
   embezzlerLog,
   globalOptions,
   HIGHLIGHT,
@@ -271,6 +271,13 @@ export function main(argString = ""): void {
     set("forbiddenStores", forbiddenStores.join(","));
   }
 
+  if (get("garbo_autoUserConfirm", false)) {
+    print(
+      "I have set auto-confirm to true and accept all ramifications that come with that.",
+      "red"
+    );
+  }
+
   if (
     !$classes`Seal Clubber, Turtle Tamer, Pastamancer, Sauceror, Disco Bandit, Accordion Thief, Cow Puncher, Snake Oiler, Beanslinger`.includes(
       myClass()
@@ -282,7 +289,7 @@ export function main(argString = ""): void {
   }
 
   if (!get("garbo_skipAscensionCheck", false) && (!get("kingLiberated") || myLevel() < 13)) {
-    const proceedRegardless = customUserConfirm(
+    const proceedRegardless = userConfirmDialog(
       "Looks like your ascension may not be done yet. Running garbo in an unintended character state can result in serious injury and even death. Are you sure you want to garbologize?",
       true
     );
@@ -333,7 +340,7 @@ export function main(argString = ""): void {
 
   if (stashItems.length > 0) {
     if (
-      customUserConfirm(
+      userConfirmDialog(
         `Garbo has detected that you have the following items still out of the stash from a previous run of garbo: ${stashItems
           .map((item) => item.name)
           .join(",")}. Would you like us to return these to the stash now?`,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -314,9 +314,9 @@ export function printHelpMenu(): void {
     +--------------------------+-----------------------------------------------------------------------------------------------+
     |       garbo_buyPass      | Set to true to buy a dinsey day pass with FunFunds at the end of the day, if possible.        |
     +--------------------------+-----------------------------------------------------------------------------------------------+
-    |   garbo_autoUserConfirm  | Don't show user confirm dialogs, instead automatically select yes/no in a way that will allow |
-    |                          |  garbo to continue executing. Useful when running garbo inside other scripts or headless.     |
-    |                          |  Use at your own risk.                                                                        |
+    |   garbo_autoUserConfirm  | **WARNING: Experimental** Don't show user confirm dialogs, instead automatically select yes/no|
+    |                          | in a way that will allow garbo to continue executing. Useful for scripting/headless. Risky and|
+    |                          |  potentially destructive.                                                                     |
     +--------------------------+-----------------------------------------------------------------------------------------------+
     |           Note:          | You can manually set these properties, but it's recommended that you use the relay interface. |
     +--------------------------+-----------------------------------------------------------------------------------------------+</pre>`);
@@ -420,8 +420,19 @@ export function getChoiceOption(partialText: string): number {
   return -1;
 }
 
-export function customUserConfirm(msg: string, defaultValue: boolean, timeOut?: number): boolean {
-  if (get("garbo_autoUserConfirm")) return defaultValue;
-  else if (timeOut) return userConfirm(msg, timeOut, defaultValue);
+/**
+ * Confirmation dialog that supports automatic resolution via garbo_autoUserConfirm preference
+ * @param msg string to display in confirmation dialog
+ * @param defaultValue default answer if user doesn't provide one
+ * @param timeOut time to show dialog before submitting default value
+ * @returns answer to confirmation dialog
+ */
+export function userConfirmDialog(msg: string, defaultValue: boolean, timeOut?: number): boolean {
+  if (get("garbo_autoUserConfirm", false)) {
+    print(`Automatically selected ${defaultValue} for ${msg}`, "red");
+    return defaultValue;
+  }
+
+  if (timeOut) return userConfirm(msg, timeOut, defaultValue);
   return userConfirm(msg);
 }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -30,6 +30,7 @@ import {
   toUrl,
   use,
   useFamiliar,
+  userConfirm,
   useSkill,
   visitUrl,
 } from "kolmafia";
@@ -313,6 +314,10 @@ export function printHelpMenu(): void {
     +--------------------------+-----------------------------------------------------------------------------------------------+
     |       garbo_buyPass      | Set to true to buy a dinsey day pass with FunFunds at the end of the day, if possible.        |
     +--------------------------+-----------------------------------------------------------------------------------------------+
+    |   garbo_autoUserConfirm  | Don't show user confirm dialogs, instead automatically select yes/no in a way that will allow |
+    |                          |  garbo to continue executing. Useful when running garbo inside other scripts or headless.     |
+    |                          |  Use at your own risk.                                                                        |
+    +--------------------------+-----------------------------------------------------------------------------------------------+
     |           Note:          | You can manually set these properties, but it's recommended that you use the relay interface. |
     +--------------------------+-----------------------------------------------------------------------------------------------+</pre>`);
 }
@@ -413,4 +418,10 @@ export function getChoiceOption(partialText: string): number {
     }
   }
   return -1;
+}
+
+export function customUserConfirm(msg: string, defaultValue: boolean, timeOut?: number): boolean {
+  if (get("garbo_autoUserConfirm")) return defaultValue;
+  else if (timeOut) return userConfirm(msg, timeOut, defaultValue);
+  return userConfirm(msg);
 }


### PR DESCRIPTION
Idea is for the auto confirmation to handle user confirms in a way aiming to ensure garbo keeps running and chooses options anticipating the most meat possible. To me it's expected that the optimal decision might not be made and that's fine since someone had to explicitly set this pref.