### PR TITLE
set nextFight later

### DIFF
--- a/src/embezzler.ts
+++ b/src/embezzler.ts
@@ -169,6 +169,7 @@ export class EmbezzlerFight {
   }
 
   run(options: { macro?: Macro; location?: Location; useAuto?: boolean } = {}): void {
+    if (!this.available()) return;
     const fightMacro = options.macro ?? embezzlerMacro();
     if (this.draggable) {
       this.execute(


### PR DESCRIPTION
As it stands, we can hit a gregarious monster during startWandererCounter, invalidating our current getNextEmbezzlerFight. This stops that by creating a temporary variable for our post-fight actions, and then only actually deciding the next embezzlerFight at the end.