### PR TITLE
initialize NEP quest before volcano stuff

### DIFF
--- a/src/dailies.ts
+++ b/src/dailies.ts
@@ -374,15 +374,16 @@ function nepQuest(): void {
 
   if (get("_questPartyFair") === "unstarted") {
     visitUrl(toUrl($location`The Neverending Party`));
-    if (["food", "booze"].includes(get("_questPartyFairQuest"))) {
-      print("Gerald/ine quest!", HIGHLIGHT);
-      globalOptions.clarasBellClaimed = true;
-    }
     if (["food", "booze", "trash", "dj"].includes(get("_questPartyFairQuest"))) {
       runChoice(1); // Accept quest
     } else {
       runChoice(2); // Decline quest
     }
+  }
+
+  if (["food", "booze"].includes(get("_questPartyFairQuest"))) {
+    print("Gerald/ine quest!", HIGHLIGHT);
+    globalOptions.clarasBellClaimed = true;
   }
 }
 

--- a/src/dailies.ts
+++ b/src/dailies.ts
@@ -35,6 +35,7 @@ import {
   toInt,
   toItem,
   toSlot,
+  toUrl,
   use,
   useFamiliar,
   useSkill,
@@ -99,6 +100,7 @@ export function dailySetup(): void {
   prepFamiliars();
   dailyBuffs();
   configureMisc();
+  nepQuest();
   volcanoDailies();
   cheat();
   tomeSummons();
@@ -363,6 +365,23 @@ function configureVykea() {
       const level = vykeas.sort((a, b) => vykeaProfit(...b) - vykeaProfit(...a))[0][0];
       retrieveItem($item`VYKEA hex key`);
       cliExecute(`create level ${level} couch`);
+    }
+  }
+}
+
+function nepQuest(): void {
+  if (!(get("neverendingPartyAlways") || get("_neverendingPartyToday"))) return;
+
+  if (get("_questPartyFair") === "unstarted") {
+    visitUrl(toUrl($location`The Neverending Party`));
+    if (["food", "booze"].includes(get("_questPartyFairQuest"))) {
+      print("Gerald/ine quest!", HIGHLIGHT);
+      globalOptions.clarasBellClaimed = true;
+    }
+    if (["food", "booze", "trash", "dj"].includes(get("_questPartyFairQuest"))) {
+      runChoice(1); // Accept quest
+    } else {
+      runChoice(2); // Decline quest
     }
   }
 }

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -45,7 +45,6 @@ import {
   toItem,
   toSlot,
   totalTurnsPlayed,
-  toUrl,
   use,
   useFamiliar,
   useSkill,
@@ -1875,18 +1874,6 @@ export function freeFights(): void {
 }
 
 function setNepQuestChoicesAndPrepItems() {
-  if (get("_questPartyFair") === "unstarted") {
-    visitUrl(toUrl($location`The Neverending Party`));
-    if (["food", "booze"].includes(get("_questPartyFairQuest"))) {
-      print("Gerald/ine quest!", HIGHLIGHT);
-      globalOptions.clarasBellClaimed = true;
-    }
-    if (["food", "booze", "trash", "dj"].includes(get("_questPartyFairQuest"))) {
-      runChoice(1); // Accept quest
-    } else {
-      runChoice(2); // Decline quest
-    }
-  }
   const quest = get("_questPartyFairQuest");
 
   if (quest === "food") {


### PR DESCRIPTION
This goes hand-in-hand with the recent-ish clarasBellClaimed tracking; we want to check this before doing volcano dailies, and we want it to re-enter nicely.