### PR TITLE
Allow string boolean, fixes #895

### DIFF
--- a/src/relay/components/BooleanInput.tsx
+++ b/src/relay/components/BooleanInput.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { useState } from "react";
 
 function BooleanInput(props: SettingProp): JSX.Element {
-  const [value, setValue] = useState(props.value === true);
+  const [value, setValue] = useState(props.value === true || props.value == "true");
 
   return (
     <label className="checkcontainer">

--- a/src/relay/components/BooleanInput.tsx
+++ b/src/relay/components/BooleanInput.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { useState } from "react";
 
 function BooleanInput(props: SettingProp): JSX.Element {
-  const [value, setValue] = useState(props.value === true || props.value == "true");
+  const [value, setValue] = useState(props.value === true || props.value === "true");
 
   return (
     <label className="checkcontainer">

--- a/src/relay/css/App.scss
+++ b/src/relay/css/App.scss
@@ -18,6 +18,7 @@ $speed: 0.4s;
 #notificationsContainer {
   position: absolute;
   width: 100%;
+  z-index: 999;
 }
 
 img {


### PR DESCRIPTION
Realistically this should be fixed by registering the properties as actual booleans or converting them to booleans before it reaches this input.