### PR TITLE
Improve meatify logic when ascending

### DIFF
--- a/src/combat.ts
+++ b/src/combat.ts
@@ -178,13 +178,13 @@ export class Macro extends StrictMacro {
       case $item`Spooky Putty sheet`:
         return this.externalIf(
           get("spookyPuttyCopiesMade") + Math.max(1, get("_raindohCopiesMade")) < 6 &&
-            $items`Spooky Putty sheet, Spooky Putty monster`.some((item) => have(item)),
+          $items`Spooky Putty sheet, Spooky Putty monster`.some((item) => have(item)),
           Macro.tryItem(itemOrSkill)
         );
       case $item`Rain-Doh black box`:
         return this.externalIf(
           get("_raindohCopiesMade") + Math.max(1, get("spookyPuttyCopiesMade")) < 6 &&
-            $items`Rain-Doh black box, Rain-Doh box full of monster`.some((item) => have(item)),
+          $items`Rain-Doh black box, Rain-Doh box full of monster`.some((item) => have(item)),
           Macro.tryItem(itemOrSkill)
         );
       case $item`4-d camera`:
@@ -254,33 +254,33 @@ export class Macro extends StrictMacro {
       .tryHaveSkill($skill`Sing Along`)
       .externalIf(
         digitizedMonstersRemaining() <= 5 - get("_meteorShowerUses") &&
-          have($skill`Meteor Lore`) &&
-          get("_meteorShowerUses") < 5,
+        have($skill`Meteor Lore`) &&
+        get("_meteorShowerUses") < 5,
         Macro.if_($monster`Knob Goblin Embezzler`, Macro.trySkill($skill`Meteor Shower`))
       )
       .trySkill($skill`Bowl Straight Up`)
       .externalIf(
         have($skill`Transcendent Olfaction`) &&
-          property.getString("olfactedMonster") !== "garbage tourist" &&
-          get("_olfactionsUsed") < 3,
+        property.getString("olfactedMonster") !== "garbage tourist" &&
+        get("_olfactionsUsed") < 3,
         Macro.if_($monster`garbage tourist`, Macro.trySkill($skill`Transcendent Olfaction`))
       )
       .externalIf(
         get("_gallapagosMonster") !== $monster`garbage tourist` &&
-          have($skill`Gallapagosian Mating Call`),
+        have($skill`Gallapagosian Mating Call`),
         Macro.if_($monster`garbage tourist`, Macro.trySkill($skill`Gallapagosian Mating Call`))
       )
       .externalIf(
         !get("_latteCopyUsed") &&
-          (get("_latteMonster") !== $monster`garbage tourist` ||
-            getCounters("Latte Monster", 0, 30).trim() === "") &&
-          have($item`latte lovers member's mug`),
+        (get("_latteMonster") !== $monster`garbage tourist` ||
+          getCounters("Latte Monster", 0, 30).trim() === "") &&
+        have($item`latte lovers member's mug`),
         Macro.if_($monster`garbage tourist`, Macro.trySkill($skill`Offer Latte to Opponent`))
       )
       .externalIf(
         get("_feelNostalgicUsed") < 3 &&
-          get("lastCopyableMonster") === $monster`garbage tourist` &&
-          have($skill`Feel Nostalgic`),
+        get("lastCopyableMonster") === $monster`garbage tourist` &&
+        have($skill`Feel Nostalgic`),
         Macro.if_(
           `!monsterid ${$monster`garbage tourist`.id}`,
           Macro.trySkill($skill`Feel Nostalgic`)
@@ -609,9 +609,9 @@ export function main(): void {
     Macro.ifHolidayWanderer(
       Macro.externalIf(
         haveEquipped($item`backup camera`) &&
-          get("_backUpUses") < 11 &&
-          get("lastCopyableMonster") === $monster`Knob Goblin Embezzler` &&
-          myFamiliar() === meatFamiliar(),
+        get("_backUpUses") < 11 &&
+        get("lastCopyableMonster") === $monster`Knob Goblin Embezzler` &&
+        myFamiliar() === meatFamiliar(),
         Macro.skill($skill`Back-Up to your Last Enemy`).step(Macro.load()),
         Macro.basicCombat()
       )

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -50,7 +50,7 @@ import {
   SourceTerminal,
   StrictMacro,
 } from "libram";
-import { meatFamiliar } from "./familiar";
+import { meatFamiliar, timeToMeatify } from "./familiar";
 import { digitizedMonstersRemaining } from "./wanderer";
 
 let monsterManuelCached: boolean | undefined = undefined;
@@ -409,9 +409,7 @@ export class Macro extends StrictMacro {
     return this.tryHaveSkill($skill`Sing Along`)
       .tryHaveSkill($skill`Curse of Weaksauce`)
       .externalIf(
-        myFamiliar() === $familiar`Grey Goose` &&
-          $familiar`Grey Goose`.experience >= 400 &&
-          !get("_meatifyMatterUsed"),
+        myFamiliar() === $familiar`Grey Goose` && timeToMeatify(),
         Macro.trySkill($skill`Meatify Matter`)
       )
       .externalIf(
@@ -564,9 +562,7 @@ export class Macro extends StrictMacro {
 
     return this.tryHaveSkill($skill`Sing Along`)
       .externalIf(
-        myFamiliar() === $familiar`Grey Goose` &&
-          $familiar`Grey Goose`.experience >= 400 &&
-          !get("_meatifyMatterUsed"),
+        myFamiliar() === $familiar`Grey Goose` && timeToMeatify(),
         Macro.trySkill($skill`Meatify Matter`)
       )
       .tryHaveItem($item`Rain-Doh blue balls`)

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -178,13 +178,13 @@ export class Macro extends StrictMacro {
       case $item`Spooky Putty sheet`:
         return this.externalIf(
           get("spookyPuttyCopiesMade") + Math.max(1, get("_raindohCopiesMade")) < 6 &&
-          $items`Spooky Putty sheet, Spooky Putty monster`.some((item) => have(item)),
+            $items`Spooky Putty sheet, Spooky Putty monster`.some((item) => have(item)),
           Macro.tryItem(itemOrSkill)
         );
       case $item`Rain-Doh black box`:
         return this.externalIf(
           get("_raindohCopiesMade") + Math.max(1, get("spookyPuttyCopiesMade")) < 6 &&
-          $items`Rain-Doh black box, Rain-Doh box full of monster`.some((item) => have(item)),
+            $items`Rain-Doh black box, Rain-Doh box full of monster`.some((item) => have(item)),
           Macro.tryItem(itemOrSkill)
         );
       case $item`4-d camera`:
@@ -254,33 +254,33 @@ export class Macro extends StrictMacro {
       .tryHaveSkill($skill`Sing Along`)
       .externalIf(
         digitizedMonstersRemaining() <= 5 - get("_meteorShowerUses") &&
-        have($skill`Meteor Lore`) &&
-        get("_meteorShowerUses") < 5,
+          have($skill`Meteor Lore`) &&
+          get("_meteorShowerUses") < 5,
         Macro.if_($monster`Knob Goblin Embezzler`, Macro.trySkill($skill`Meteor Shower`))
       )
       .trySkill($skill`Bowl Straight Up`)
       .externalIf(
         have($skill`Transcendent Olfaction`) &&
-        property.getString("olfactedMonster") !== "garbage tourist" &&
-        get("_olfactionsUsed") < 3,
+          property.getString("olfactedMonster") !== "garbage tourist" &&
+          get("_olfactionsUsed") < 3,
         Macro.if_($monster`garbage tourist`, Macro.trySkill($skill`Transcendent Olfaction`))
       )
       .externalIf(
         get("_gallapagosMonster") !== $monster`garbage tourist` &&
-        have($skill`Gallapagosian Mating Call`),
+          have($skill`Gallapagosian Mating Call`),
         Macro.if_($monster`garbage tourist`, Macro.trySkill($skill`Gallapagosian Mating Call`))
       )
       .externalIf(
         !get("_latteCopyUsed") &&
-        (get("_latteMonster") !== $monster`garbage tourist` ||
-          getCounters("Latte Monster", 0, 30).trim() === "") &&
-        have($item`latte lovers member's mug`),
+          (get("_latteMonster") !== $monster`garbage tourist` ||
+            getCounters("Latte Monster", 0, 30).trim() === "") &&
+          have($item`latte lovers member's mug`),
         Macro.if_($monster`garbage tourist`, Macro.trySkill($skill`Offer Latte to Opponent`))
       )
       .externalIf(
         get("_feelNostalgicUsed") < 3 &&
-        get("lastCopyableMonster") === $monster`garbage tourist` &&
-        have($skill`Feel Nostalgic`),
+          get("lastCopyableMonster") === $monster`garbage tourist` &&
+          have($skill`Feel Nostalgic`),
         Macro.if_(
           `!monsterid ${$monster`garbage tourist`.id}`,
           Macro.trySkill($skill`Feel Nostalgic`)
@@ -609,9 +609,9 @@ export function main(): void {
     Macro.ifHolidayWanderer(
       Macro.externalIf(
         haveEquipped($item`backup camera`) &&
-        get("_backUpUses") < 11 &&
-        get("lastCopyableMonster") === $monster`Knob Goblin Embezzler` &&
-        myFamiliar() === meatFamiliar(),
+          get("_backUpUses") < 11 &&
+          get("lastCopyableMonster") === $monster`Knob Goblin Embezzler` &&
+          myFamiliar() === meatFamiliar(),
         Macro.skill($skill`Back-Up to your Last Enemy`).step(Macro.load()),
         Macro.basicCombat()
       )

--- a/src/familiar.ts
+++ b/src/familiar.ts
@@ -225,31 +225,49 @@ export function pocketProfessorLectures(): number {
 }
 
 export function timeToMeatify(): boolean {
-  if (!have($familiar`Grey Goose`) || get("_meatifyMatterUsed") || myInebriety() > inebrietyLimit()) return false;
-  else if ($familiar`Grey Goose`.experience >= 400) return true;
+  if (
+    !have($familiar`Grey Goose`) ||
+    get("_meatifyMatterUsed") ||
+    myInebriety() > inebrietyLimit()
+  ) {
+    return false;
+  } else if ($familiar`Grey Goose`.experience >= 400) return true;
   else if (!globalOptions.ascending || myAdventures() > 50) return false;
 
-  // Check Wanderers  
+  // Check Wanderers
   const totalTurns = totalTurnsPlayed();
-  const baseMeat = (have($item`SongBoom™ BoomBox`)) ? 275 : 250;
-  const usingLatte = (have($item`latte lovers member's mug`) && get("latteModifier").split(",").includes("Meat Drop: 40")) ? true : false;
+  const baseMeat = have($item`SongBoom™ BoomBox`) ? 275 : 250;
+  const usingLatte =
+    have($item`latte lovers member's mug`) &&
+    get("latteModifier").split(",").includes("Meat Drop: 40");
 
-  const nextProtonicGhost = (have($item`protonic accelerator pack`)) ? Math.max(0, get("nextParanormalActivity") - totalTurns) : Infinity;
-  const nextVoteMonster = (have($item`"I Voted!" sticker`) && get("_voteFreeFights") < 3) ? Math.max(0, (totalTurns % 11 - 1) % 11) : Infinity;  
-  const nextVoidMonster = (have($item`cursed magnifying glass`) && get("_voidFreeFights") < 5 && get("valueOfFreeFight", 2000) / 13 > baseMeat * (usingLatte ? 0.75 : 0.6)) ? -get("cursedMagnifyingGlassCount") % 13 : Infinity;
+  const nextProtonicGhost = have($item`protonic accelerator pack`)
+    ? Math.max(0, get("nextParanormalActivity") - totalTurns)
+    : Infinity;
+  const nextVoteMonster =
+    have($item`"I Voted!" sticker`) && get("_voteFreeFights") < 3
+      ? Math.max(0, ((totalTurns % 11) - 1) % 11)
+      : Infinity;
+  const nextVoidMonster =
+    have($item`cursed magnifying glass`) &&
+    get("_voidFreeFights") < 5 &&
+    get("valueOfFreeFight", 2000) / 13 > baseMeat * (usingLatte ? 0.75 : 0.6)
+      ? -get("cursedMagnifyingGlassCount") % 13
+      : Infinity;
 
   // If any of the above are 0, then
   // (1) We should be fighting a free fight
   // (2) We meatify if Grey Goose is sufficiently heavy and we don't have another free wanderer in our remaining turns
-  
-  const freeFightNow = (nextProtonicGhost === 0 || nextVoteMonster === 0 || nextVoidMonster === 0);
-  const delay = [
-    (nextProtonicGhost === 0) ? 50 : nextProtonicGhost,
-    (nextVoteMonster === 0) ? ((get("_voteFreeFights") < 2) ? 11 : Infinity) : nextVoteMonster,    
-    (nextVoidMonster === 0) ? 13 : nextVoidMonster,
-  ].reduce((a, b) => (a < b) ? a : b);
 
-  if (delay < myAdventures()) return false; // We can wait for the next free fight
+  const freeFightNow = nextProtonicGhost === 0 || nextVoteMonster === 0 || nextVoidMonster === 0;
+  const delay = [
+    nextProtonicGhost === 0 ? 50 : nextProtonicGhost,
+    nextVoteMonster === 0 ? (get("_voteFreeFights") < 2 ? 11 : Infinity) : nextVoteMonster,
+    nextVoidMonster === 0 ? 13 : nextVoidMonster,
+  ].reduce((a, b) => (a < b ? a : b));
+
+  if (delay < myAdventures()) return false;
+  // We can wait for the next free fight
   else if (freeFightNow || $familiar`Grey Goose`.experience >= 121) return true;
 
   return false;

--- a/src/familiar.ts
+++ b/src/familiar.ts
@@ -229,27 +229,23 @@ export function timeToMeatify(): boolean {
   else if ($familiar`Grey Goose`.experience >= 400) return true;
   else if (!globalOptions.ascending || myAdventures() > 50) return false;
 
-  // Check Wanderers
-  // const F = get("_sausageFights");
+  // Check Wanderers  
   const totalTurns = totalTurnsPlayed();
   const baseMeat = (have($item`SongBoom™ BoomBox`)) ? 275 : 250;
   const usingLatte = (have($item`latte lovers member's mug`) && get("latteModifier").split(",").includes("Meat Drop: 40")) ? true : false;
 
   const nextProtonicGhost = (have($item`protonic accelerator pack`)) ? Math.max(0, get("nextParanormalActivity") - totalTurns) : Infinity;
-  const nextVoteMonster = (have($item`"I Voted!" sticker`) && get("_voteFreeFights") < 3) ? Math.max(0, (totalTurns % 11 - 1) % 11) : Infinity;
-  // const nextSausageGoblin = (have($item`Kramco Sausage-o-Matic™`)) ? Math.max(0, 4 + 3 * F + Math.pow(Math.max(0, F-5), 3) + get("_lastSausageMonsterTurn") - totalTurns) : Infinity;
+  const nextVoteMonster = (have($item`"I Voted!" sticker`) && get("_voteFreeFights") < 3) ? Math.max(0, (totalTurns % 11 - 1) % 11) : Infinity;  
   const nextVoidMonster = (have($item`cursed magnifying glass`) && get("_voidFreeFights") < 5 && get("valueOfFreeFight", 2000) / 13 > baseMeat * (usingLatte ? 0.75 : 0.6)) ? -get("cursedMagnifyingGlassCount") % 13 : Infinity;
 
   // If any of the above are 0, then
   // (1) We should be fighting a free fight
   // (2) We meatify if Grey Goose is sufficiently heavy and we don't have another free wanderer in our remaining turns
-
-  // const freeFightNow = (nextProtonicGhost === 0 || nextVoteMonster === 0 || nextSausageGoblin === 0 || nextVoidMonster === 0);
+  
   const freeFightNow = (nextProtonicGhost === 0 || nextVoteMonster === 0 || nextVoidMonster === 0);
   const delay = [
     (nextProtonicGhost === 0) ? 50 : nextProtonicGhost,
-    (nextVoteMonster === 0) ? ((get("_voteFreeFights") < 2) ? 11 : Infinity) : nextVoteMonster,
-    // (nextSausageGoblin === 0) ? 7 + 3 * F + Math.pow(Math.max(0, F-4), 3) : nextSausageGoblin,
+    (nextVoteMonster === 0) ? ((get("_voteFreeFights") < 2) ? 11 : Infinity) : nextVoteMonster,    
     (nextVoidMonster === 0) ? 13 : nextVoidMonster,
   ].reduce((a, b) => (a < b) ? a : b);
 

--- a/src/familiar.ts
+++ b/src/familiar.ts
@@ -228,30 +228,30 @@ export function timeToMeatify(): boolean {
   if (!have($familiar`Grey Goose`) || get("_meatifyMatterUsed") || myInebriety() > inebrietyLimit()) return false;
   else if ($familiar`Grey Goose`.experience >= 400) return true;
   else if (!globalOptions.ascending || myAdventures() > 50) return false;
-  
-  //Check Wanderers
+
+  // Check Wanderers
   const F = get("_sausageFights");
   const totalTurns = totalTurnsPlayed();
 
   const nextProtonicGhost = (have($item`protonic accelerator pack`)) ? Math.max(0, get("nextParanormalActivity") - totalTurns) : Infinity;
   const nextVoteMonster = (have($item`"I Voted!" sticker`) && get("_voteFreeFights") < 3) ? Math.max(0, (totalTurns % 11 - 1) % 11) : Infinity;
-  const nextSausageGoblin = (have($item`Kramco Sausage-o-Matic™`)) ? Math.max(0, 4 + 3 * F + Math.pow(Math.max(0, F-5), 3) + get("_lastSausageMonsterTurn") - totalTurns) : Infinity;
-  const nextVoidMonster = (have($item`cursed magnifying glass`) && get("_voidFreeFights") < 5) ? -get("cursedMagnifyingGlassCount") % 13 : Infinity;	
+  // const nextSausageGoblin = (have($item`Kramco Sausage-o-Matic™`)) ? Math.max(0, 4 + 3 * F + Math.pow(Math.max(0, F-5), 3) + get("_lastSausageMonsterTurn") - totalTurns) : Infinity;
+  const nextVoidMonster = (have($item`cursed magnifying glass`) && get("_voidFreeFights") < 5) ? -get("cursedMagnifyingGlassCount") % 13 : Infinity;
 
-  //If any of the above are 0, then
-  //(1) We should be fighting a free fight
-  //(2) We meatify if Grey Goose is sufficiently heavy and we don't have another free wanderer in our remaining turns
-  
-  const freeFightNow = (nextProtonicGhost === 0 || nextVoteMonster === 0 || nextSausageGoblin === 0 || nextVoidMonster === 0);  
+  // If any of the above are 0, then
+  // (1) We should be fighting a free fight
+  // (2) We meatify if Grey Goose is sufficiently heavy and we don't have another free wanderer in our remaining turns
+
+  const freeFightNow = (nextProtonicGhost === 0 || nextVoteMonster === 0 || nextSausageGoblin === 0 || nextVoidMonster === 0);
   const delay = [
     (nextProtonicGhost === 0) ? 50 : nextProtonicGhost,
     (nextVoteMonster === 0) ? ((get("_voteFreeFights") < 2) ? 11 : Infinity) : nextVoteMonster,
-    (nextSausageGoblin === 0) ? 7 + 3 * F + Math.pow(Math.max(0, F-4), 3) : nextSausageGoblin,
+    // (nextSausageGoblin === 0) ? 7 + 3 * F + Math.pow(Math.max(0, F-4), 3) : nextSausageGoblin,
     (nextVoidMonster === 0) ? 13 : nextVoidMonster,
-  ].reduce((a, b) => (a < b) ? a : b);	
+  ].reduce((a, b) => (a < b) ? a : b);
 
   if (delay < myAdventures()) return false; //We can wait for the next free fight
   else if (freeFightNow || $familiar`Grey Goose`.experience >= 121) return true;
-  
+
   return false;
 }

--- a/src/familiar.ts
+++ b/src/familiar.ts
@@ -227,7 +227,7 @@ export function pocketProfessorLectures(): number {
 export function timeToMeatify(): boolean {
   if (!have($familiar`Grey Goose`) || get("_meatifyMatterUsed") || myInebriety() > inebrietyLimit()) return false;
   else if ($familiar`Grey Goose`.experience >= 400) return true;
-  else if (!globalOptions.ascending) return false;
+  else if (!globalOptions.ascending || myAdventures() > 50) return false;
   
   //Check Wanderers
   const F = get("_sausageFights");

--- a/src/familiar.ts
+++ b/src/familiar.ts
@@ -230,7 +230,7 @@ export function timeToMeatify(): boolean {
   else if (!globalOptions.ascending || myAdventures() > 50) return false;
 
   // Check Wanderers
-  const F = get("_sausageFights");
+  // const F = get("_sausageFights");
   const totalTurns = totalTurnsPlayed();
 
   const nextProtonicGhost = (have($item`protonic accelerator pack`)) ? Math.max(0, get("nextParanormalActivity") - totalTurns) : Infinity;

--- a/src/familiar.ts
+++ b/src/familiar.ts
@@ -250,8 +250,8 @@ export function timeToMeatify(): boolean {
       : Infinity;
   const nextVoidMonster =
     have($item`cursed magnifying glass`) &&
-      get("_voidFreeFights") < 5 &&
-      get("valueOfFreeFight", 2000) / 13 > baseMeat * (usingLatte ? 0.75 : 0.6)
+    get("_voidFreeFights") < 5 &&
+    get("valueOfFreeFight", 2000) / 13 > baseMeat * (usingLatte ? 0.75 : 0.6)
       ? -get("cursedMagnifyingGlassCount") % 13
       : Infinity;
 
@@ -259,7 +259,8 @@ export function timeToMeatify(): boolean {
   // (1) We should be fighting a free fight
   // (2) We meatify if Grey Goose is sufficiently heavy and we don't have another free wanderer in our remaining turns
 
-  const freeFightNow = get("questPAGhost") !== "unstarted" || nextVoteMonster === 0 || nextVoidMonster === 0;
+  const freeFightNow =
+    get("questPAGhost") !== "unstarted" || nextVoteMonster === 0 || nextVoidMonster === 0;
   const delay = [
     nextProtonicGhost,
     nextVoteMonster === 0 ? (get("_voteFreeFights") < 2 ? 11 : Infinity) : nextVoteMonster,

--- a/src/familiar.ts
+++ b/src/familiar.ts
@@ -232,17 +232,20 @@ export function timeToMeatify(): boolean {
   // Check Wanderers
   // const F = get("_sausageFights");
   const totalTurns = totalTurnsPlayed();
+  const baseMeat = (have($item`SongBoom™ BoomBox`)) ? 275 : 250;
+  const usingLatte = (have($item`latte lovers member's mug`) && get("latteModifier").split(",").includes("Meat Drop\: 40")) ? true : false;
 
   const nextProtonicGhost = (have($item`protonic accelerator pack`)) ? Math.max(0, get("nextParanormalActivity") - totalTurns) : Infinity;
   const nextVoteMonster = (have($item`"I Voted!" sticker`) && get("_voteFreeFights") < 3) ? Math.max(0, (totalTurns % 11 - 1) % 11) : Infinity;
   // const nextSausageGoblin = (have($item`Kramco Sausage-o-Matic™`)) ? Math.max(0, 4 + 3 * F + Math.pow(Math.max(0, F-5), 3) + get("_lastSausageMonsterTurn") - totalTurns) : Infinity;
-  const nextVoidMonster = (have($item`cursed magnifying glass`) && get("_voidFreeFights") < 5) ? -get("cursedMagnifyingGlassCount") % 13 : Infinity;
+  const nextVoidMonster = (have($item`cursed magnifying glass`) && get("_voidFreeFights") < 5 && get("valueOfFreeFight", 2000) / 13 > baseMeat * (usingLatte ? 0.75 : 0.6)) ? -get("cursedMagnifyingGlassCount") % 13 : Infinity;
 
   // If any of the above are 0, then
   // (1) We should be fighting a free fight
   // (2) We meatify if Grey Goose is sufficiently heavy and we don't have another free wanderer in our remaining turns
 
-  const freeFightNow = (nextProtonicGhost === 0 || nextVoteMonster === 0 || nextSausageGoblin === 0 || nextVoidMonster === 0);
+  // const freeFightNow = (nextProtonicGhost === 0 || nextVoteMonster === 0 || nextSausageGoblin === 0 || nextVoidMonster === 0);
+  const freeFightNow = (nextProtonicGhost === 0 || nextVoteMonster === 0 || nextVoidMonster === 0);
   const delay = [
     (nextProtonicGhost === 0) ? 50 : nextProtonicGhost,
     (nextVoteMonster === 0) ? ((get("_voteFreeFights") < 2) ? 11 : Infinity) : nextVoteMonster,

--- a/src/familiar.ts
+++ b/src/familiar.ts
@@ -242,7 +242,7 @@ export function timeToMeatify(): boolean {
     get("latteModifier").split(",").includes("Meat Drop: 40");
 
   const nextProtonicGhost = have($item`protonic accelerator pack`)
-    ? Math.max(0, get("nextParanormalActivity") - totalTurns)
+    ? Math.max(1, get("nextParanormalActivity") - totalTurns)
     : Infinity;
   const nextVoteMonster =
     have($item`"I Voted!" sticker`) && get("_voteFreeFights") < 3
@@ -259,9 +259,9 @@ export function timeToMeatify(): boolean {
   // (1) We should be fighting a free fight
   // (2) We meatify if Grey Goose is sufficiently heavy and we don't have another free wanderer in our remaining turns
 
-  const freeFightNow = nextProtonicGhost === 0 || nextVoteMonster === 0 || nextVoidMonster === 0;
+  const freeFightNow = get("questPAGhost") !== "unstarted" || nextVoteMonster === 0 || nextVoidMonster === 0;
   const delay = [
-    nextProtonicGhost === 0 ? 50 : nextProtonicGhost,
+    nextProtonicGhost,
     nextVoteMonster === 0 ? (get("_voteFreeFights") < 2 ? 11 : Infinity) : nextVoteMonster,
     nextVoidMonster === 0 ? 13 : nextVoidMonster,
   ].reduce((a, b) => (a < b ? a : b));

--- a/src/familiar.ts
+++ b/src/familiar.ts
@@ -233,7 +233,7 @@ export function timeToMeatify(): boolean {
   // const F = get("_sausageFights");
   const totalTurns = totalTurnsPlayed();
   const baseMeat = (have($item`SongBoom™ BoomBox`)) ? 275 : 250;
-  const usingLatte = (have($item`latte lovers member's mug`) && get("latteModifier").split(",").includes("Meat Drop\: 40")) ? true : false;
+  const usingLatte = (have($item`latte lovers member's mug`) && get("latteModifier").split(",").includes("Meat Drop: 40")) ? true : false;
 
   const nextProtonicGhost = (have($item`protonic accelerator pack`)) ? Math.max(0, get("nextParanormalActivity") - totalTurns) : Infinity;
   const nextVoteMonster = (have($item`"I Voted!" sticker`) && get("_voteFreeFights") < 3) ? Math.max(0, (totalTurns % 11 - 1) % 11) : Infinity;
@@ -253,7 +253,7 @@ export function timeToMeatify(): boolean {
     (nextVoidMonster === 0) ? 13 : nextVoidMonster,
   ].reduce((a, b) => (a < b) ? a : b);
 
-  if (delay < myAdventures()) return false; //We can wait for the next free fight
+  if (delay < myAdventures()) return false; // We can wait for the next free fight
   else if (freeFightNow || $familiar`Grey Goose`.experience >= 121) return true;
 
   return false;

--- a/src/familiar.ts
+++ b/src/familiar.ts
@@ -224,7 +224,7 @@ export function pocketProfessorLectures(): number {
   return 2 + Math.ceil(Math.sqrt(familiarWeight($familiar`Pocket Professor`) + weightAdjustment()));
 }
 
-function timeToMeatify(): boolean {
+export function timeToMeatify(): boolean {
   if (!have($familiar`Grey Goose`) || get("_meatifyMatterUsed") || myInebriety() > inebrietyLimit()) return false;
   else if ($familiar`Grey Goose`.experience >= 400) return true;
   else if (!globalOptions.ascending) return false;

--- a/src/familiar.ts
+++ b/src/familiar.ts
@@ -250,8 +250,8 @@ export function timeToMeatify(): boolean {
       : Infinity;
   const nextVoidMonster =
     have($item`cursed magnifying glass`) &&
-    get("_voidFreeFights") < 5 &&
-    get("valueOfFreeFight", 2000) / 13 > baseMeat * (usingLatte ? 0.75 : 0.6)
+      get("_voidFreeFights") < 5 &&
+      get("valueOfFreeFight", 2000) / 13 > baseMeat * (usingLatte ? 0.75 : 0.6)
       ? -get("cursedMagnifyingGlassCount") % 13
       : Infinity;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ import {
   $classes,
   $coinmaster,
   $effect,
+  $familiar,
   $item,
   $items,
   $location,

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ import {
 } from "libram";
 import { Macro, withMacro } from "./combat";
 import { runDiet } from "./diet";
-import { freeFightFamiliar, meatFamiliar } from "./familiar";
+import { freeFightFamiliar, meatFamiliar, timeToMeatify } from "./familiar";
 import { dailyFights, freeFights, printEmbezzlerLog } from "./fights";
 import {
   checkGithubVersion,
@@ -193,6 +193,8 @@ function barfTurn() {
       }
       retrieveItem($item`pulled green taffy`);
       if (!have($effect`Fishy`)) use($item`fishy pipe`);
+    } else if (timeToMeatify()) {
+      useFamiliar($familiar`Grey Goose`);
     }
 
     // d. get dressed

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,7 +194,7 @@ function barfTurn() {
       }
       retrieveItem($item`pulled green taffy`);
       if (!have($effect`Fishy`)) use($item`fishy pipe`);
-    } else if (timeToMeatify()) {
+    } else if (!embezzlerUp && timeToMeatify()) {
       useFamiliar($familiar`Grey Goose`);
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -206,11 +206,11 @@ function barfTurn() {
       myInebriety() > inebrietyLimit() &&
       globalOptions.ascending &&
       clamp(myAdventures() - digitizedMonstersRemaining(), 1, myAdventures()) <=
-      availableAmount($item`Map to Safety Shelter Grimace Prime`)
+        availableAmount($item`Map to Safety Shelter Grimace Prime`)
     ) {
       const choiceToSet =
         availableAmount($item`distention pill`) <
-          availableAmount($item`synthetic dog hair pill`) +
+        availableAmount($item`synthetic dog hair pill`) +
           availableAmount($item`Map to Safety Shelter Grimace Prime`)
           ? 1
           : 2;

--- a/src/index.ts
+++ b/src/index.ts
@@ -206,11 +206,11 @@ function barfTurn() {
       myInebriety() > inebrietyLimit() &&
       globalOptions.ascending &&
       clamp(myAdventures() - digitizedMonstersRemaining(), 1, myAdventures()) <=
-        availableAmount($item`Map to Safety Shelter Grimace Prime`)
+      availableAmount($item`Map to Safety Shelter Grimace Prime`)
     ) {
       const choiceToSet =
         availableAmount($item`distention pill`) <
-        availableAmount($item`synthetic dog hair pill`) +
+          availableAmount($item`synthetic dog hair pill`) +
           availableAmount($item`Map to Safety Shelter Grimace Prime`)
           ? 1
           : 2;


### PR DESCRIPTION
Meatify Matter will try to trigger on the last possible free fight wanderer if the ascend flag is true, or any time under 50 adventures left if no free fight wanderers are available