### PR TITLE
Saber Forces aren't tentaclable

### DIFF
--- a/src/fights.ts
+++ b/src/fights.ts
@@ -912,7 +912,7 @@ const freeFightSources = [
         );
       }
     },
-    true,
+    false,
     {
       requirements: () => [
         new Requirement([], { forceEquip: $items`Fourth of May Cosplay Saber` }),


### PR DESCRIPTION
Changed sabering for maps in Grimace to not be tentaclable to try and prevent acquiring eldritch attunement on reentry