### PR TITLE
Use Uncle Gator's instead of Barf for jelly fishing

### DIFF
--- a/src/fights.ts
+++ b/src/fights.ts
@@ -636,7 +636,7 @@ const pygmyMacro = Macro.if_(
 
 function getStenchLocation() {
   return (
-    $locations`Barf Mountain, The Hippy Camp (Bombed Back to the Stone Age), The Dark and Spooky Swamp`.find(
+    $locations`Uncle Gator's Country Fun-Time Liquid Waste Sluice, The Hippy Camp (Bombed Back to the Stone Age), The Dark and Spooky Swamp`.find(
       (l) => canAdv(l, false)
     ) || $location`none`
   );


### PR DESCRIPTION
This is to avoid the Barf NC which takes a turn