### PR TITLE
allow moods to execute using mp restore items

### DIFF
--- a/src/mood.ts
+++ b/src/mood.ts
@@ -8,6 +8,7 @@ import {
   myClass,
   myLevel,
   numericModifier,
+  restoreMp,
   use,
   useSkill,
 } from "kolmafia";
@@ -21,7 +22,10 @@ import {
   AsdonMartin,
   get,
   have,
+  MagicalSausages,
   Mood,
+  MpSource,
+  OscusSoda,
   set,
   uneffect,
   Witchess,
@@ -30,6 +34,26 @@ import { baseMeat, questStep, safeRestoreMpTarget, setChoice } from "./lib";
 import { withStash } from "./clan";
 import { usingPurse } from "./outfit";
 
+class MpRestoreItem implements MpSource {
+  static instance = new MpRestoreItem();
+
+  usesRemaining(): number {
+    return Infinity;
+  }
+
+  availableMpMin(): number {
+    return Infinity;
+  }
+
+  availableMpMax(): number {
+    return Infinity;
+  }
+
+  execute(): void {
+    restoreMp(100);
+  }
+}
+
 Mood.setDefaultOptions({
   songSlots: [
     $effects`Polka of Plenty`,
@@ -37,6 +61,7 @@ Mood.setDefaultOptions({
     $effects`Chorale of Companionship`,
     $effects`The Ballad of Richie Thingfinder`,
   ],
+  mpSources: [OscusSoda.instance, MagicalSausages.instance, MpRestoreItem.instance],
 });
 
 export function meatMood(urKels = false): Mood {

--- a/src/mood.ts
+++ b/src/mood.ts
@@ -58,7 +58,7 @@ Mood.setDefaultOptions({
   songSlots: [
     $effects`Polka of Plenty`,
     $effects`Fat Leon's Phat Loot Lyric, Ur-Kel's Aria of Annoyance`,
-    $effects`Chorale of Companionship`,
+    $effects`Chorale of Companionship, Paul's Passionate Pop Song`,
     $effects`The Ballad of Richie Thingfinder`,
   ],
   mpSources: [OscusSoda.instance, MagicalSausages.instance, MpRestoreItem.instance],
@@ -82,6 +82,7 @@ export function meatMood(urKels = false): Mood {
   mood.skill($skill`The Polka of Plenty`);
   mood.skill($skill`Disco Leer`);
   mood.skill(urKels ? $skill`Ur-Kel's Aria of Annoyance` : $skill`Fat Leon's Phat Loot Lyric`);
+  if (!have($effect`Chorale of Companionship`)) mood.skill($skill`Paul's Passionate Pop Song`);
   mood.skill($skill`Singer's Faithful Ocelot`);
   mood.skill($skill`The Spirit of Taking`);
   mood.skill($skill`Drescher's Annoying Noise`);


### PR DESCRIPTION
Right now, moods will only restore mp to execute using sausages or oscus's soda.

For people without kramco, this is less than ideal.