### PR TITLE
Shrug polka if we are out of song slots for ode

### DIFF
--- a/src/yachtzee.ts
+++ b/src/yachtzee.ts
@@ -253,10 +253,11 @@ function castOde(turns: number): boolean {
 
   shrugIrrelevantSongs();
 
-  // This is the most inefficient song out of all those that we run
-  // and we can usually buff this ourselves after shrugging (no need to buy recordings)
+  // If we have the polka of plenty skill, we can re-buff up later
+  // Else, get rid of chorale which is the most inefficient song
   if (getActiveSongs.length === (have($skill`Mariachi Memory`) ? 4 : 3)) {
-    cliExecute(`shrug ${$effect`Polka of Plenty`}`);
+    if (have($skill`The Polka of Plenty`)) cliExecute(`shrug ${$effect`Polka of Plenty`}`);
+    else cliExecute(`shrug ${$effect`Chorale of Companionship`}`);
   }
 
   while (haveEffect($effect`Ode to Booze`) < turns) {

--- a/src/yachtzee.ts
+++ b/src/yachtzee.ts
@@ -253,6 +253,12 @@ function castOde(turns: number): boolean {
 
   shrugIrrelevantSongs();
 
+  // This is the most inefficient song out of all those that we run
+  // and we can usually buff this ourselves after shrugging (no need to buy recordings)
+  if (getActiveSongs.length === (have($skill`Mariachi Memory`) ? 4 : 3)) {
+    cliExecute(`shrug ${$effect`Polka of Plenty`}`);
+  }
+
   while (haveEffect($effect`Ode to Booze`) < turns) {
     useSkill($skill`The Ode to Booze`);
   }
@@ -1177,6 +1183,15 @@ function _yachtzeeChain(): void {
         Math.min(jellyTurns, fishyTurns)
       );
       if (bestWaterBreathingEquipment.item !== $item`none`) equip(bestWaterBreathingEquipment.item);
+    }
+    if (!have($effect`Polka of Plenty`)) {
+      if (have($effect`Ode to Booze`)) cliExecute(`shrug ${$effect`Ode to Booze`}`);
+      if (
+        getActiveSongs().length < (have($skill`Mariachi Memory`) ? 4 : 3) &&
+        have($skill`The Polka of Plenty`)
+      ) {
+        useSkill($skill`The Polka of Plenty`);
+      }
     }
     adventureMacro($location`The Sunken Party Yacht`, Macro.abort());
     if (myTurncount() > turncount || haveEffect($effect`Fishy`) < fishyTurns) {


### PR DESCRIPTION
This is only triggered after shrugIrrelevantSongs(), so the only songs that are left to shrug would be polka, chorale and ballad, and polka is the cheapest to buff up again (of the 3).
However, if we don't have the skill to buff up again (i.e. the effect was obtained from a buffbot prior to running garbo), then don't shrug polka (else we would run the rest of garbo without it).