### PR TITLE
Only use pasta eyeball when profitable

### DIFF
--- a/src/fights.ts
+++ b/src/fights.ts
@@ -107,6 +107,7 @@ import {
   pocketProfessorLectures,
 } from "./familiar";
 import {
+  baseMeat,
   burnLibrams,
   dogOrHolidayWanderer,
   embezzlerLog,
@@ -126,7 +127,7 @@ import {
   setChoice,
   userConfirmDialog,
 } from "./lib";
-import { freeFightMood, meatMood } from "./mood";
+import { freeFightMood, lagsambieMood, meatMood } from "./mood";
 import { freeFightOutfit, meatOutfit, tryFillLatte, waterBreathingEquipment } from "./outfit";
 import { bathroomFinance, potionSetup } from "./potions";
 import {
@@ -192,6 +193,7 @@ function embezzlerSetup() {
   potionSetup(false);
   maximize("MP", false);
   meatMood(true).execute(estimatedTurns());
+  lagsambieMood(750 + baseMeat).execute(embezzlerCount());
   safeRestore();
   freeFightMood().execute(50);
   withStash($items`Platinum Yendorian Express Card, Bag o' Tricks`, () => {

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -127,14 +127,13 @@ import {
   setChoice,
   userConfirmDialog,
 } from "./lib";
-import { freeFightMood, lagsambieMood, meatMood } from "./mood";
+import { freeFightMood, meatMood } from "./mood";
 import { freeFightOutfit, meatOutfit, tryFillLatte, waterBreathingEquipment } from "./outfit";
 import { bathroomFinance, potionSetup } from "./potions";
 import {
   embezzlerCount,
   embezzlerMacro,
   embezzlerSources,
-  estimatedTurns,
   getNextEmbezzlerFight,
 } from "./embezzler";
 import { canAdv } from "canadv.ash";
@@ -192,8 +191,7 @@ function embezzlerSetup() {
   setLocation($location`none`);
   potionSetup(false);
   maximize("MP", false);
-  meatMood(true).execute(estimatedTurns());
-  lagsambieMood(750 + baseMeat).execute(embezzlerCount());
+  meatMood(true, 750 + baseMeat).execute(embezzlerCount());
   safeRestore();
   freeFightMood().execute(50);
   withStash($items`Platinum Yendorian Express Card, Bag o' Tricks`, () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,6 @@ import { runDiet } from "./diet";
 import { freeFightFamiliar, meatFamiliar, timeToMeatify } from "./familiar";
 import { dailyFights, deliverThesisIfAble, freeFights, printEmbezzlerLog } from "./fights";
 import {
-  baseMeat,
   bestJuneCleaverOption,
   checkGithubVersion,
   embezzlerLog,
@@ -82,7 +81,7 @@ import {
   steveAdventures,
   userConfirmDialog,
 } from "./lib";
-import { lagsambieMood, meatMood } from "./mood";
+import { meatMood } from "./mood";
 import postCombatActions from "./post";
 import {
   familiarWaterBreathingEquipment,
@@ -162,7 +161,6 @@ function barfTurn() {
 
   // a. set up mood stuff
   meatMood().execute(estimatedTurns());
-  lagsambieMood(baseMeat).execute(estimatedTurns());
 
   safeRestore(); // get enough mp to use summer siesta and enough hp to not get our ass kicked
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ import { runDiet } from "./diet";
 import { freeFightFamiliar, meatFamiliar, timeToMeatify } from "./familiar";
 import { dailyFights, deliverThesisIfAble, freeFights, printEmbezzlerLog } from "./fights";
 import {
+  baseMeat,
   bestJuneCleaverOption,
   checkGithubVersion,
   embezzlerLog,
@@ -81,7 +82,7 @@ import {
   steveAdventures,
   userConfirmDialog,
 } from "./lib";
-import { meatMood } from "./mood";
+import { lagsambieMood, meatMood } from "./mood";
 import postCombatActions from "./post";
 import {
   familiarWaterBreathingEquipment,
@@ -161,6 +162,7 @@ function barfTurn() {
 
   // a. set up mood stuff
   meatMood().execute(estimatedTurns());
+  lagsambieMood(baseMeat).execute(estimatedTurns());
 
   safeRestore(); // get enough mp to use summer siesta and enough hp to not get our ass kicked
 

--- a/src/mood.ts
+++ b/src/mood.ts
@@ -29,6 +29,7 @@ import {
 import { baseMeat, questStep, safeRestoreMpTarget, setChoice } from "./lib";
 import { withStash } from "./clan";
 import { usingPurse } from "./outfit";
+import { garboValue } from "./session";
 
 Mood.setDefaultOptions({
   songSlots: [
@@ -204,15 +205,17 @@ function shrugBadEffects(...exclude: Effect[]) {
   });
 }
 
-const mmjCost =
-  100 - (have($skill`Five Finger Discount`) ? 5 : 0) - (have($item`Travoltan trousers`) ? 5 : 0);
-
 export function lagsambieMood(meat: number): Mood {
   const mood = new Mood({ reserveMp: safeRestoreMpTarget() });
-  if (
-    myClass() !== $class`Pastamancer` &&
-    0.1 * meat * 10 > mmjCost * (200 / (1.5 * myLevel() + 5))
-  ) {
+  const mmjCost =
+    (100 -
+      (have($skill`Five Finger Discount`) ? 5 : 0) -
+      (have($item`Travoltan trousers`) ? 5 : 0)) *
+    (200 / (1.5 * myLevel() + 5));
+  const genericManaPotionCost = garboValue($item`generic mana potion`) * (200 / (2.5 * myLevel()));
+  const mpRestorerCost = Math.min(mmjCost, genericManaPotionCost);
+
+  if (myClass() !== $class`Pastamancer` && 0.1 * meat * 10 > mpRestorerCost) {
     mood.skill($skill`Bind Lasagmbie`);
   }
   return mood;

--- a/src/mood.ts
+++ b/src/mood.ts
@@ -63,8 +63,6 @@ export function meatMood(urKels = false): Mood {
   mood.skill($skill`Drescher's Annoying Noise`);
   mood.skill($skill`Pride of the Puffin`);
 
-  if (myClass() !== $class`Pastamancer`) mood.skill($skill`Bind Lasagmbie`);
-
   if (getWorkshed() === $item`Asdon Martin keyfob`) mood.drive(AsdonMartin.Driving.Observantly);
 
   if (have($item`Kremlin's Greatest Briefcase`)) {
@@ -204,4 +202,18 @@ function shrugBadEffects(...exclude: Effect[]) {
       uneffect(effect);
     }
   });
+}
+
+const mmjCost =
+  100 - (have($skill`Five Finger Discount`) ? 5 : 0) - (have($item`Travoltan trousers`) ? 5 : 0);
+
+export function lagsambieMood(meat: number): Mood {
+  const mood = new Mood({ reserveMp: safeRestoreMpTarget() });
+  if (
+    myClass() !== $class`Pastamancer` &&
+    0.1 * meat * 10 > mmjCost * (200 / (1.5 * myLevel() + 5))
+  ) {
+    mood.skill($skill`Bind Lasagmbie`);
+  }
+  return mood;
 }

--- a/src/mood.ts
+++ b/src/mood.ts
@@ -5,6 +5,7 @@ import {
   getWorkshed,
   haveEffect,
   itemAmount,
+  mallPrice,
   myClass,
   myLevel,
   numericModifier,
@@ -29,7 +30,6 @@ import {
 import { baseMeat, questStep, safeRestoreMpTarget, setChoice } from "./lib";
 import { withStash } from "./clan";
 import { usingPurse } from "./outfit";
-import { garboValue } from "./session";
 
 Mood.setDefaultOptions({
   songSlots: [
@@ -69,7 +69,7 @@ export function meatMood(urKels = false, meat = baseMeat): Mood {
       (have($skill`Five Finger Discount`) ? 5 : 0) -
       (have($item`Travoltan trousers`) ? 5 : 0)) *
     (200 / (1.5 * myLevel() + 5));
-  const genericManaPotionCost = garboValue($item`generic mana potion`) * (200 / (2.5 * myLevel()));
+  const genericManaPotionCost = mallPrice($item`generic mana potion`) * (200 / (2.5 * myLevel()));
   const mpRestorerCost = Math.min(mmjCost, genericManaPotionCost);
 
   if (myClass() !== $class`Pastamancer` && 0.1 * meat * 10 > mpRestorerCost) {

--- a/src/mood.ts
+++ b/src/mood.ts
@@ -41,7 +41,7 @@ Mood.setDefaultOptions({
   useNativeRestores: true,
 });
 
-export function meatMood(urKels = false): Mood {
+export function meatMood(urKels = false, meat = baseMeat): Mood {
   // Reserve the amount of MP we try to restore before each fight.
   const mood = new Mood({ reserveMp: safeRestoreMpTarget() });
 
@@ -63,6 +63,18 @@ export function meatMood(urKels = false): Mood {
   mood.skill($skill`The Spirit of Taking`);
   mood.skill($skill`Drescher's Annoying Noise`);
   mood.skill($skill`Pride of the Puffin`);
+
+  const mmjCost =
+    (100 -
+      (have($skill`Five Finger Discount`) ? 5 : 0) -
+      (have($item`Travoltan trousers`) ? 5 : 0)) *
+    (200 / (1.5 * myLevel() + 5));
+  const genericManaPotionCost = garboValue($item`generic mana potion`) * (200 / (2.5 * myLevel()));
+  const mpRestorerCost = Math.min(mmjCost, genericManaPotionCost);
+
+  if (myClass() !== $class`Pastamancer` && 0.1 * meat * 10 > mpRestorerCost) {
+    mood.skill($skill`Bind Lasagmbie`);
+  }
 
   if (getWorkshed() === $item`Asdon Martin keyfob`) mood.drive(AsdonMartin.Driving.Observantly);
 
@@ -203,20 +215,4 @@ function shrugBadEffects(...exclude: Effect[]) {
       uneffect(effect);
     }
   });
-}
-
-export function lagsambieMood(meat: number): Mood {
-  const mood = new Mood({ reserveMp: safeRestoreMpTarget() });
-  const mmjCost =
-    (100 -
-      (have($skill`Five Finger Discount`) ? 5 : 0) -
-      (have($item`Travoltan trousers`) ? 5 : 0)) *
-    (200 / (1.5 * myLevel() + 5));
-  const genericManaPotionCost = garboValue($item`generic mana potion`) * (200 / (2.5 * myLevel()));
-  const mpRestorerCost = Math.min(mmjCost, genericManaPotionCost);
-
-  if (myClass() !== $class`Pastamancer` && 0.1 * meat * 10 > mpRestorerCost) {
-    mood.skill($skill`Bind Lasagmbie`);
-  }
-  return mood;
 }

--- a/src/yachtzee.ts
+++ b/src/yachtzee.ts
@@ -66,7 +66,7 @@ import { acquire } from "./acquire";
 import { withStash } from "./clan";
 import { prepFamiliars } from "./dailies";
 import { runDiet } from "./diet";
-import { embezzlerCount, EmbezzlerFight, embezzlerSources, estimatedTurns } from "./embezzler";
+import { embezzlerCount, EmbezzlerFight, embezzlerSources } from "./embezzler";
 import { hasMonsterReplacers } from "./extrovermectin";
 import { doSausage } from "./fights";
 import {
@@ -77,7 +77,7 @@ import {
   safeRestore,
   turnsToNC,
 } from "./lib";
-import { lagsambieMood, meatMood } from "./mood";
+import { meatMood } from "./mood";
 import { familiarWaterBreathingEquipment, waterBreathingEquipment } from "./outfit";
 import { farmingPotions, mutuallyExclusive, Potion, potionSetup } from "./potions";
 import { garboValue } from "./session";
@@ -1136,8 +1136,7 @@ function _yachtzeeChain(): void {
   );
 
   maximize("MP", false);
-  meatMood(false).execute(estimatedTurns());
-  lagsambieMood(750 + baseMeat).execute(embezzlerCount());
+  meatMood(false, 750 + baseMeat).execute(embezzlerCount());
   potionSetup(false); // This is the default set up for embezzlers (which helps us estimate if chaining is better than extros)
   maximizeMeat();
   prepareOutfitAndFamiliar();
@@ -1171,7 +1170,7 @@ function _yachtzeeChain(): void {
   if (haveEffect($effect`Beaten Up`)) {
     uneffect($effect`Beaten Up`);
   }
-  lagsambieMood(2000).execute(Math.min(jellyTurns, fishyTurns));
+  meatMood(false, 2000).execute(Math.min(jellyTurns, fishyTurns));
   safeRestore();
 
   let plantCrookweed = true;

--- a/src/yachtzee.ts
+++ b/src/yachtzee.ts
@@ -66,7 +66,7 @@ import { acquire } from "./acquire";
 import { withStash } from "./clan";
 import { prepFamiliars } from "./dailies";
 import { runDiet } from "./diet";
-import { EmbezzlerFight, embezzlerSources, estimatedTurns } from "./embezzler";
+import { embezzlerCount, EmbezzlerFight, embezzlerSources, estimatedTurns } from "./embezzler";
 import { hasMonsterReplacers } from "./extrovermectin";
 import { doSausage } from "./fights";
 import {
@@ -77,7 +77,7 @@ import {
   safeRestore,
   turnsToNC,
 } from "./lib";
-import { meatMood } from "./mood";
+import { lagsambieMood, meatMood } from "./mood";
 import { familiarWaterBreathingEquipment, waterBreathingEquipment } from "./outfit";
 import { farmingPotions, mutuallyExclusive, Potion, potionSetup } from "./potions";
 import { garboValue } from "./session";
@@ -1137,6 +1137,7 @@ function _yachtzeeChain(): void {
 
   maximize("MP", false);
   meatMood(false).execute(estimatedTurns());
+  lagsambieMood(750 + baseMeat).execute(embezzlerCount());
   potionSetup(false); // This is the default set up for embezzlers (which helps us estimate if chaining is better than extros)
   maximizeMeat();
   prepareOutfitAndFamiliar();
@@ -1170,6 +1171,7 @@ function _yachtzeeChain(): void {
   if (haveEffect($effect`Beaten Up`)) {
     uneffect($effect`Beaten Up`);
   }
+  lagsambieMood(2000).execute(Math.min(jellyTurns, fishyTurns));
   safeRestore();
 
   let plantCrookweed = true;


### PR DESCRIPTION
It is egregiously bad for character levels < 35 (for barf tourists; it may be marginally profitable for embezzlies and yachtzees at a lower level), even with MMJs. We use MMJs as a benchmark to see if it is indeed profitable for the account to run it.