### PR TITLE
Fix gas can acquire to match macro usage

### DIFF
--- a/src/fights.ts
+++ b/src/fights.ts
@@ -796,7 +796,12 @@ const freeFightSources = [
           if (have($skill`Mathematical Precision`)) ensureEffect($effect`Mathematically Precise`);
           if (have($skill`Blood Bubble`)) ensureEffect($effect`Blood Bubble`);
           retrieveItem($item`[glitch season reward name]`);
-          if (get("glitchItemImplementationCount") >= 1000) retrieveItem($item`gas can`, 2);
+          if (
+            get("glitchItemImplementationCount") * itemAmount($item`[glitch season reward name]`) >=
+            2000
+          ) {
+            retrieveItem($item`gas can`, 2);
+          }
           visitUrl("inv_eat.php?pwd&whichitem=10207");
           runCombat();
         }


### PR DESCRIPTION
This caused an abort for me today because it didn't acquire the cans then tried to throw them