### PR TITLE
Prefer git dependencies for repos that prefer git installs

### DIFF
--- a/mafia/dependencies.txt
+++ b/mafia/dependencies.txt
@@ -2,5 +2,5 @@ https://github.com/Ezandora/Bastille/branches/Release/
 https://github.com/Ezandora/Gain/branches/Release/
 https://github.com/Ezandora/Briefcase/branches/Release/
 https://github.com/Ezandora/Far-Future/branches/Release/
-https://github.com/Loathing-Associates-Scripting-Society/KoL-MineVolcano/branches/master/RELEASE/
-https://github.com/Loathing-Associates-Scripting-Society/combo/branches/release/
+https://github.com/Loathing-Associates-Scripting-Society/KoL-MineVolcano.git
+https://github.com/Loathing-Associates-Scripting-Society/combo.git release


### PR DESCRIPTION
KoL-MineVolcano and combo have switched to recommending they be installed using git. Switch the dependencies accordingly.