### PR TITLE
acquire - not buy - UPC stickers

### DIFF
--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -1,6 +1,5 @@
 import {
   bjornifyFamiliar,
-  buy,
   canAdventure,
   canEquip,
   cliExecute,
@@ -38,6 +37,7 @@ import {
   have,
   Requirement,
 } from "libram";
+import { acquire } from "./acquire";
 import { bestBjornalike, bonusGear, pickBjorn, valueBjornModifiers } from "./dropsgear";
 import { embezzlerCount } from "./embezzler";
 import { meatFamiliar } from "./familiar";
@@ -230,7 +230,7 @@ export function meatOutfit(embezzlerUp: boolean, requirement?: Requirement, sea?
     const addedValueOfFullSword = (embezzlers * ((75 - currentWeapon) * (750 + baseMeat))) / 100;
     if (addedValueOfFullSword > 3 * mallPrice(UPC)) {
       const needed = 3 - stickerSlots.filter((sticker) => equippedItem(sticker) === UPC).length;
-      if (needed) buy(needed, UPC, addedValueOfFullSword / 3);
+      if (needed) acquire(needed, UPC, addedValueOfFullSword / 3);
       useUPCs();
     }
   }

--- a/src/yachtzee.ts
+++ b/src/yachtzee.ts
@@ -1,7 +1,6 @@
 import {
   availableAmount,
   booleanModifier,
-  buy,
   canAdventure,
   canEquip,
   canInteract,
@@ -1195,7 +1194,7 @@ function stickerSetup(expectedYachts: number) {
     ((75 - embezzlerOpportunityCost) * Math.min(20, expectedEmbezzlers) * (750 + baseMeat)) / 100;
   if (mallPrice(UPC) < addedValueOfFullSword / 3) {
     const needed = 3 - currentStickers.filter((sticker) => sticker === UPC).length;
-    if (needed) buy(needed, UPC, addedValueOfFullSword / 3);
+    if (needed) acquire(needed, UPC, addedValueOfFullSword / 3);
     useUPCs();
   }
 }


### PR DESCRIPTION
use acquire() rather than buy() for UPC sticker acquisition so as to utilise stickers in inventory. 