### PR TITLE
Better dynamically-stepped yachtzee

### DIFF
--- a/src/embezzler.ts
+++ b/src/embezzler.ts
@@ -912,11 +912,29 @@ export function estimatedTurns(): number {
   const thumbRingMultiplier = usingThumbRing() ? 1 / 0.96 : 1;
 
   // We need to estimate adventures from our organs if we are only dieting after yachtzee chaining
-  const fullnessAdventures = (fullnessLimit() - myFullness()) * 8;
-  const inebrietyAdventures = (inebrietyLimit() - myInebriety()) * 7;
+  const distentionPillSpace = have($item`distention pill`) && !get("_distentionPillUsed") ? 1 : 0;
+  const syntheticPillSpace =
+    have($item`synthetic dog hair pill`) && !get("_syntheticDogHairPillUsed") ? 1 : 0;
+  const shotglassSpace = have($item`mime army shotglass`) && !get("_mimeArmyShotglassUsed") ? 1 : 0;
+  const sweatSpace = have($item`designer sweatpants`) ? 3 - get("_sweatOutSomeBoozeUsed") : 0;
+  const fullnessAdventures = (fullnessLimit() - myFullness() + distentionPillSpace) * 8;
+  const inebrietyAdventures =
+    (inebrietyLimit() - myInebriety() + syntheticPillSpace + sweatSpace + shotglassSpace) * 7;
+  const borrowedTimeAdventures = globalOptions.ascending && !get("_borrowedTimeUsed") ? 20 : 0;
+  const chocolateAdventures = ((3 - get("_chocolatesUsed")) * (4 - get("_chocolatesUsed"))) / 2;
+  const yachtzeeTurns = 30; // guesstimate
+  const bufferAdventures = 30; // We don't know if garbo would decide to use melange/voraci tea/sweet tooth to get more adventures
   const adventuresAfterChaining =
     globalOptions.yachtzeeChain && !get("_garboYachtzeeChainCompleted")
-      ? Math.max(fullnessAdventures + inebrietyAdventures - 30, 0)
+      ? Math.max(
+          fullnessAdventures +
+            inebrietyAdventures +
+            borrowedTimeAdventures +
+            chocolateAdventures +
+            bufferAdventures -
+            yachtzeeTurns,
+          0
+        )
       : 0;
 
   let turns;

--- a/src/embezzler.ts
+++ b/src/embezzler.ts
@@ -892,6 +892,29 @@ export function embezzlerCount(): number {
   return sum(embezzlerSources, (source: EmbezzlerFight) => source.potential());
 }
 
+function potentialFullnessAdventures(): number {
+  const distentionPillSpace = have($item`distention pill`) && !get("_distentionPillUsed") ? 1 : 0;
+
+  return (fullnessLimit() - myFullness() + distentionPillSpace) * 8;
+}
+
+function potentialInebrietyAdventures(): number {
+  const syntheticPillSpace =
+    have($item`synthetic dog hair pill`) && !get("_syntheticDogHairPillUsed") ? 1 : 0;
+  const shotglassSpace = have($item`mime army shotglass`) && !get("_mimeArmyShotglassUsed") ? 1 : 0;
+  const sweatSpace = have($item`designer sweatpants`) ? 3 - get("_sweatOutSomeBoozeUsed") : 0;
+
+  return (inebrietyLimit() - myInebriety() + syntheticPillSpace + sweatSpace + shotglassSpace) * 7;
+}
+
+function potentialNonOrganAdventures(): number {
+  const borrowedTimeAdventures = globalOptions.ascending && !get("_borrowedTimeUsed") ? 20 : 0;
+  const chocolateAdventures = ((3 - get("_chocolatesUsed")) * (4 - get("_chocolatesUsed"))) / 2;
+  const bufferAdventures = 30; // We don't know if garbo would decide to use melange/voraci tea/sweet tooth to get more adventures
+
+  return borrowedTimeAdventures + chocolateAdventures + bufferAdventures;
+}
+
 export function estimatedTurns(): number {
   // Assume roughly 2 fullness from pantsgiving and 8 adventures/fullness.
   const pantsgivingAdventures = have($item`Pantsgiving`)
@@ -912,26 +935,13 @@ export function estimatedTurns(): number {
   const thumbRingMultiplier = usingThumbRing() ? 1 / 0.96 : 1;
 
   // We need to estimate adventures from our organs if we are only dieting after yachtzee chaining
-  const distentionPillSpace = have($item`distention pill`) && !get("_distentionPillUsed") ? 1 : 0;
-  const syntheticPillSpace =
-    have($item`synthetic dog hair pill`) && !get("_syntheticDogHairPillUsed") ? 1 : 0;
-  const shotglassSpace = have($item`mime army shotglass`) && !get("_mimeArmyShotglassUsed") ? 1 : 0;
-  const sweatSpace = have($item`designer sweatpants`) ? 3 - get("_sweatOutSomeBoozeUsed") : 0;
-  const fullnessAdventures = (fullnessLimit() - myFullness() + distentionPillSpace) * 8;
-  const inebrietyAdventures =
-    (inebrietyLimit() - myInebriety() + syntheticPillSpace + sweatSpace + shotglassSpace) * 7;
-  const borrowedTimeAdventures = globalOptions.ascending && !get("_borrowedTimeUsed") ? 20 : 0;
-  const chocolateAdventures = ((3 - get("_chocolatesUsed")) * (4 - get("_chocolatesUsed"))) / 2;
   const yachtzeeTurns = 30; // guesstimate
-  const bufferAdventures = 30; // We don't know if garbo would decide to use melange/voraci tea/sweet tooth to get more adventures
   const adventuresAfterChaining =
     globalOptions.yachtzeeChain && !get("_garboYachtzeeChainCompleted")
       ? Math.max(
-          fullnessAdventures +
-            inebrietyAdventures +
-            borrowedTimeAdventures +
-            chocolateAdventures +
-            bufferAdventures -
+          potentialFullnessAdventures() +
+            potentialInebrietyAdventures() +
+            potentialNonOrganAdventures() -
             yachtzeeTurns,
           0
         )

--- a/src/yachtzee.ts
+++ b/src/yachtzee.ts
@@ -531,7 +531,9 @@ function optimizeForFishy(yachtzeeTurns: number, setup?: boolean): number {
         acquire(1, $item`fish juice box`, 1.2 * mallPrice($item`fish juice box`));
         if (!have($item`fish juice box`)) throw new Error("Unable to obtain fish juice box");
         use(1, $item`fish juice box`);
-        if (haveFishyPipe) use(1, $item`fishy pipe`);
+        if (haveFishyPipe && haveEffect($effect`Fishy`) + adventureExtensionBonus < yachtzeeTurns) {
+          use(1, $item`fishy pipe`);
+        }
       },
     },
     {

--- a/src/yachtzee.ts
+++ b/src/yachtzee.ts
@@ -675,11 +675,14 @@ export function yachtzeeChainDiet(simOnly?: boolean): boolean {
     (3 - get("_sweatOutSomeBoozeUsed", 0));
   const spleenAvailable = currentSpleenLeft + filters;
   const organsAvailable = fullnessAvailable + inebrietyAvailable + spleenAvailable;
-  const sufficientOrgansFor30 =
-    organsAvailable - synthCastsToCoverRun - extroSpleenSpace >= 30 + 5 * toInt(havePYECCharge);
-  const sufficientOrgansFor20 =
-    organsAvailable - synthCastsToCoverRun - extroSpleenSpace >= 20 + 5 * toInt(havePYECCharge);
-  const baseYachtzeeTurns = sufficientOrgansFor30 ? 30 : sufficientOrgansFor20 ? 20 : 10;
+
+  const cleanableSpleen = organsAvailable - synthCastsToCoverRun - extroSpleenSpace;
+  const sufficientOrgansFor = (yachtzees: number) =>
+    cleanableSpleen >= yachtzees + (havePYECCharge ? 5 : 0);
+  const possibleBaseYachtzeeTurns = [30, 20, 10];
+  const baseYachtzeeTurns = possibleBaseYachtzeeTurns.reduce((a, b) =>
+    sufficientOrgansFor(a) ? a : b
+  );
 
   const maxYachtzeeTurns = havePYECCharge ? baseYachtzeeTurns + 5 : baseYachtzeeTurns;
   print(`Synth Casts Wanted: ${synthCastsToCoverRun}`, "blue");

--- a/src/yachtzee.ts
+++ b/src/yachtzee.ts
@@ -673,9 +673,11 @@ export function yachtzeeChainDiet(simOnly?: boolean): boolean {
     (3 - get("_sweatOutSomeBoozeUsed", 0));
   const spleenAvailable = currentSpleenLeft + filters;
   const organsAvailable = fullnessAvailable + inebrietyAvailable + spleenAvailable;
-  const sufficientOrgans =
+  const sufficientOrgansFor30 =
     organsAvailable - synthCastsToCoverRun - extroSpleenSpace >= 30 + 5 * toInt(havePYECCharge);
-  const baseYachtzeeTurns = sufficientOrgans ? 30 : 10;
+  const sufficientOrgansFor20 =
+    organsAvailable - synthCastsToCoverRun - extroSpleenSpace >= 20 + 5 * toInt(havePYECCharge);
+  const baseYachtzeeTurns = sufficientOrgansFor30 ? 30 : sufficientOrgansFor20 ? 20 : 10;
 
   const maxYachtzeeTurns = havePYECCharge ? baseYachtzeeTurns + 5 : baseYachtzeeTurns;
   print(`Synth Casts Wanted: ${synthCastsToCoverRun}`, "blue");

--- a/src/yachtzee.ts
+++ b/src/yachtzee.ts
@@ -679,10 +679,14 @@ export function yachtzeeChainDiet(simOnly?: boolean): boolean {
   const cleanableSpleen = organsAvailable - synthCastsToCoverRun - extroSpleenSpace;
   const sufficientOrgansFor = (yachtzees: number) =>
     cleanableSpleen >= yachtzees + (havePYECCharge ? 5 : 0);
+
   const possibleBaseYachtzeeTurns = [30, 20, 10];
-  const baseYachtzeeTurns = possibleBaseYachtzeeTurns.reduce((a, b) =>
-    sufficientOrgansFor(a) ? a : b
-  );
+  const baseYachtzeeTurns = possibleBaseYachtzeeTurns.find(sufficientOrgansFor) ?? 0;
+
+  if (baseYachtzeeTurns === 0) {
+    print("Determined that there are no suitable number of turns to chain yachtzees", "red");
+    return false;
+  }
 
   const maxYachtzeeTurns = havePYECCharge ? baseYachtzeeTurns + 5 : baseYachtzeeTurns;
   print(`Synth Casts Wanted: ${synthCastsToCoverRun}`, "blue");


### PR DESCRIPTION
We lose significant gains from chaining if we are not able to cover our barfTurns with synth all the way till the end of day.

Previous estimatedTurns() did not factor in organ cleansers, shotglass, borrowed time and chocolates, which massively underestimated the number of turns of synth / organ space we needed to fully cover our run till the end of day.

PR also adds an additional chain-length of 20/25, which fits nicely with pocket wishes (our most expensive buff), allowing us to potentially earn more from a longer chain while also fully benefitting from pocket wish buffs.