### PR TITLE
gitAtHead support

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "core-js": "^3.8.0",
-    "kolmafia": "^3.2.0",
+    "kolmafia": "^4.0.1",
     "libram": "^0.6.24",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/src/dailies.ts
+++ b/src/dailies.ts
@@ -26,7 +26,7 @@ import {
   myHp,
   myInebriety,
   myMaxhp,
-  myPathId,
+  myPath,
   myPrimestat,
   myThrall,
   pickedPockets,
@@ -174,7 +174,7 @@ function voterSetup(): void {
 
   if (!get("voteAlways") && !get("_voteToday")) {
     const availableInitiatives: Map<string, number> = new Map(
-      Object.keys(votingBoothInitiatives(myClass(), myPathId(), myDaycount())).map((init) => {
+      Object.keys(votingBoothInitiatives(myClass(), myPath(), myDaycount())).map((init) => {
         const val = initPriority.get(init) ?? 0;
         return [init, val];
       })

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,6 @@ import {
   have,
   haveInCampground,
   JuneCleaver,
-  property,
   Requirement,
   set,
   setDefaultMaximizeOptions,
@@ -325,13 +324,7 @@ export function canContinue(): boolean {
 
 export function main(argString = ""): void {
   sinceKolmafiaRevision(26634);
-  print(`${process.env.GITHUB_REPOSITORY}@${process.env.GITHUB_SHA}`);
-  const forbiddenStores = property.getString("forbiddenStores").split(",");
-  if (!forbiddenStores.includes("3408540")) {
-    // Van & Duffel's Baleet Shop
-    forbiddenStores.push("3408540");
-    set("forbiddenStores", forbiddenStores.join(","));
-  }
+  checkGithubVersion();
 
   if (get("garbo_autoUserConfirm", false)) {
     print(
@@ -394,7 +387,6 @@ export function main(argString = ""): void {
     } else if (arg.match(/yachtzeechain/)) {
       globalOptions.yachtzeeChain = true;
     } else if (arg.match(/version/i)) {
-      checkGithubVersion();
       return;
     } else if (arg) {
       print(`Invalid argument ${arg} passed. Run garbo help to see valid arguments.`, "red");

--- a/src/index.ts
+++ b/src/index.ts
@@ -323,7 +323,7 @@ export function canContinue(): boolean {
 }
 
 export function main(argString = ""): void {
-  sinceKolmafiaRevision(26634);
+  sinceKolmafiaRevision(26713);
   checkGithubVersion();
 
   if (get("garbo_autoUserConfirm", false)) {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -379,6 +379,9 @@ export function safeRestore(): void {
   burnLibrams(mpTarget * 2); // Leave a mp buffer when burning
 }
 
+/**
+ * Compares the local version of Garbo against the most recent release branch, printing results to the CLI
+ */
 export function checkGithubVersion(): void {
   if (process.env.GITHUB_REPOSITORY === "CustomBuild") {
     print("Skipping version check for custom build");

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -386,13 +386,13 @@ export function checkGithubVersion(): void {
   if (process.env.GITHUB_REPOSITORY === "CustomBuild") {
     print("Skipping version check for custom build");
   } else {
-    const gitBranches: { name: string; commit: { sha: string } }[] = JSON.parse(
-      visitUrl(`https://api.github.com/repos/${process.env.GITHUB_REPOSITORY}/branches`)
-    );
-    const releaseCommit = gitBranches.find((branchInfo) => branchInfo.name === "release")?.commit;
     if (gitAtHead("Loathing-Associates-Scripting-Society-garbage-collector-release")) {
       print("Garbo is up to date!", HIGHLIGHT);
     } else {
+      const gitBranches: { name: string; commit: { sha: string } }[] = JSON.parse(
+        visitUrl(`https://api.github.com/repos/${process.env.GITHUB_REPOSITORY}/branches`)
+      );
+      const releaseCommit = gitBranches.find((branchInfo) => branchInfo.name === "release")?.commit;
       print("Garbo is out of date. Please run 'git update!'", "red");
       print(
         `Local Version: ${

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -7,6 +7,8 @@ import {
   fileToBuffer,
   gametimeToInt,
   getLocketMonsters,
+  gitAtHead,
+  gitInfo,
   handlingChoice,
   haveSkill,
   inebrietyLimit,
@@ -384,13 +386,17 @@ export function checkGithubVersion(): void {
     const gitBranches: { name: string; commit: { sha: string } }[] = JSON.parse(
       visitUrl(`https://api.github.com/repos/${process.env.GITHUB_REPOSITORY}/branches`)
     );
-    const mainBranch = gitBranches.find((branchInfo) => branchInfo.name === "main");
-    const mainSha = mainBranch && mainBranch.commit ? mainBranch.commit.sha : "CustomBuild";
-    if (process.env.GITHUB_SHA === mainSha) {
+    const releaseCommit = gitBranches.find((branchInfo) => branchInfo.name === "release")?.commit;
+    if (gitAtHead("Loathing-Associates-Scripting-Society-garbage-collector-release")) {
       print("Garbo is up to date!", HIGHLIGHT);
     } else {
-      print("Garbo is out of date. Please run 'svn update!", "red");
-      print(`${process.env.GITHUB_REPOSITORY}/main is at ${mainSha}`);
+      print("Garbo is out of date. Please run 'git update!'", "red");
+      print(
+        `Local Version: ${
+          gitInfo("Loathing-Associates-Scripting-Society-garbage-collector-release").commit
+        }.`
+      );
+      print(`Release Version: ${releaseCommit}.`);
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2789,10 +2789,10 @@ klona@^2.0.4:
   resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.5.tgz#d166574d90076395d9963aa7a928fabb8d76afbc"
   integrity sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==
 
-kolmafia@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/kolmafia/-/kolmafia-3.2.0.tgz#2178d202ee521016fc396ea41bb4025ab3c1638a"
-  integrity sha512-CogD/3pKMFvbZ+IPDEE6yJrYcJKLrY6M8evgTbLExjyb6SwxlbtTIsNykL0iH6wvec1fD7sztPvL1hDeGsUEFA==
+kolmafia@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/kolmafia/-/kolmafia-4.0.1.tgz#361b2cea9bf668a7dc4a4c2339a009d2e1e1cd00"
+  integrity sha512-qH/A3ZwSqVADzLfNmFsNe0vyfnuSi/Ql6ZaWaJ6y6eMasBbcieTL0w3d0bSvbQj9Oe00MsmeZeJNOlV863rxNA==
 
 levn@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
- Bumped KoLmafia to 4.0.1
- Swapped a call to `myPathId()` to `myPath()` in accordance with `votingBoothInitiatives()` change
- Removed ensuring Van & Duffel's Baleet Shop is a forbidden store
- Changed `checkGitVersion()` to utilize `gitAtHead()`
- Swapped to calling `checkGitVersion()` every time garbo is run

All feedback welcome, thank you for your hard work maintaining this wonderful script.