### PR TITLE
Add estimated turns for jellyfish

### DIFF
--- a/src/familiar/freeFightFamiliar.ts
+++ b/src/familiar/freeFightFamiliar.ts
@@ -47,7 +47,7 @@ export function menu(options: MenuOptions = {}): GeneralFamiliar[] {
         familiar: $familiar`Crimbo Shrub`,
         expectedValue: 2500,
         leprechaunMultiplier: 0,
-        limit: "shrub",
+        limit: "special",
       });
     }
 
@@ -58,7 +58,7 @@ export function menu(options: MenuOptions = {}): GeneralFamiliar[] {
           garboValue($item`stench jelly`) /
           (get("_spaceJellyfishDrops") < 5 ? get("_spaceJellyfishDrops") + 1 : 20),
         leprechaunMultiplier: 0,
-        limit: "jellyfish",
+        limit: "special",
       });
     }
   }

--- a/src/familiar/freeFightFamiliar.ts
+++ b/src/familiar/freeFightFamiliar.ts
@@ -47,7 +47,7 @@ export function menu(options: MenuOptions = {}): GeneralFamiliar[] {
         familiar: $familiar`Crimbo Shrub`,
         expectedValue: 2500,
         leprechaunMultiplier: 0,
-        limit: "special",
+        limit: "shrub",
       });
     }
 
@@ -58,7 +58,7 @@ export function menu(options: MenuOptions = {}): GeneralFamiliar[] {
           garboValue($item`stench jelly`) /
           (get("_spaceJellyfishDrops") < 5 ? get("_spaceJellyfishDrops") + 1 : 20),
         leprechaunMultiplier: 0,
-        limit: "special",
+        limit: "jellyfish",
       });
     }
   }
@@ -75,6 +75,22 @@ export function menu(options: MenuOptions = {}): GeneralFamiliar[] {
   }
 
   return familiarMenu;
+}
+
+export function getAllJellyfishDrops(): { expectedValue: number; expectedTurns: number }[] {
+  if (!have($familiar`Space Jellyfish`)) return [{ expectedValue: 0, expectedTurns: 0 }];
+
+  const current = get("_spaceJellyfishDrops");
+  const returnValue = [];
+
+  for (let turns = current + 1; turns <= 6; turns++) {
+    returnValue.push({
+      expectedValue: garboValue($item`stench jelly`) / (turns > 5 ? 20 : turns),
+      expectedTurns: turns > 5 ? Infinity : turns,
+    });
+  }
+
+  return returnValue;
 }
 
 export function freeFightFamiliarData(options: MenuOptions = {}): GeneralFamiliar {

--- a/src/familiar/lib.ts
+++ b/src/familiar/lib.ts
@@ -14,7 +14,7 @@ export type GeneralFamiliar = {
   familiar: Familiar;
   expectedValue: number;
   leprechaunMultiplier: number;
-  limit: "drops" | "experience" | "none" | "shrub" | "jellyfish";
+  limit: "drops" | "experience" | "none" | "special";
 };
 
 export function timeToMeatify(): boolean {

--- a/src/familiar/lib.ts
+++ b/src/familiar/lib.ts
@@ -14,7 +14,7 @@ export type GeneralFamiliar = {
   familiar: Familiar;
   expectedValue: number;
   leprechaunMultiplier: number;
-  limit: "drops" | "experience" | "none" | "special";
+  limit: "drops" | "experience" | "none" | "shrub" | "jellyfish";
 };
 
 export function timeToMeatify(): boolean {

--- a/src/familiar/marginalFamiliars.ts
+++ b/src/familiar/marginalFamiliars.ts
@@ -117,7 +117,7 @@ function turnsNeededForFamiliar(
       return 0;
 
     case "shrub":
-      return 0;
+      return Math.ceil(estimatedTurns() / 100);
 
     case "jellyfish":
       return sum(

--- a/src/familiar/marginalFamiliars.ts
+++ b/src/familiar/marginalFamiliars.ts
@@ -116,18 +116,8 @@ function turnsNeededForFamiliar(
     case "none":
       return 0;
 
-    case "shrub":
-      return Math.ceil(estimatedTurns() / 100);
-
-    case "jellyfish":
-      return sum(
-        getAllJellyfishDrops().filter(
-          ({ expectedValue }) =>
-            outfitValue + familiarAbilityValue(familiar) + expectedValue >
-            totalFamiliarValue(baselineToCompareAgainst)
-        ),
-        ({ expectedTurns }) => expectedTurns
-      );
+    case "special":
+      return getSpecialFamiliarLimit({ familiar, outfitValue, baselineToCompareAgainst });
   }
 }
 
@@ -168,7 +158,6 @@ export function barfFamiliar(): Familiar {
         ({ familiar }) => familiar === $familiar`Crimbo Shrub`
       );
       return shrubAvailable ? $familiar`Crimbo Shrub` : meatFamiliar();
-      ```
     }
   }
 
@@ -189,4 +178,32 @@ export function barfFamiliar(): Familiar {
   );
 
   return best.familiar;
+}
+
+function getSpecialFamiliarLimit({
+  familiar,
+  outfitValue,
+  baselineToCompareAgainst,
+}: {
+  familiar: Familiar;
+  outfitValue: number;
+  baselineToCompareAgainst: GeneralFamiliar & { outfitWeight: number; outfitValue: number };
+}): number {
+  switch (familiar) {
+    case $familiar`Space Jellyfish`:
+      return sum(
+        getAllJellyfishDrops().filter(
+          ({ expectedValue }) =>
+            outfitValue + familiarAbilityValue(familiar) + expectedValue >
+            totalFamiliarValue(baselineToCompareAgainst)
+        ),
+        ({ expectedTurns }) => expectedTurns
+      );
+
+    case $familiar`Crimbo Shrub`:
+      return Math.ceil(estimatedTurns() / 100);
+
+    default:
+      return 0;
+  }
 }

--- a/src/familiar/marginalFamiliars.ts
+++ b/src/familiar/marginalFamiliars.ts
@@ -164,10 +164,11 @@ export function barfFamiliar(): Familiar {
     );
 
     if (turnsNeeded < estimatedTurns()) {
-      return (
-        viableMenu.find((familiar) => familiar.familiar === $familiar`Crimbo Shrub`)?.familiar ??
-        meatFamiliar()
+      const shrubAvailable = viableMenu.some(
+        ({ familiar }) => familiar === $familiar`Crimbo Shrub`
       );
+      return shrubAvailable ? $familiar`Crimbo Shrub` : meatFamiliar();
+      ```
     }
   }
 

--- a/src/familiar/marginalFamiliars.ts
+++ b/src/familiar/marginalFamiliars.ts
@@ -28,7 +28,7 @@ import { baseMeat, HIGHLIGHT } from "../lib";
 import { meatOutfit } from "../outfit";
 import { getAllDrops } from "./dropFamiliars";
 import { getExperienceFamiliarLimit } from "./experienceFamiliars";
-import { menu } from "./freeFightFamiliar";
+import { getAllJellyfishDrops, menu } from "./freeFightFamiliar";
 import { GeneralFamiliar, timeToMeatify } from "./lib";
 import { meatFamiliar } from "./meatFamiliar";
 
@@ -116,8 +116,18 @@ function turnsNeededForFamiliar(
     case "none":
       return 0;
 
-    case "special":
+    case "shrub":
       return 0;
+
+    case "jellyfish":
+      return sum(
+        getAllJellyfishDrops().filter(
+          ({ expectedValue }) =>
+            outfitValue + familiarAbilityValue(familiar) + expectedValue >
+            totalFamiliarValue(baselineToCompareAgainst)
+        ),
+        ({ expectedTurns }) => expectedTurns
+      );
   }
 }
 
@@ -153,7 +163,12 @@ export function barfFamiliar(): Familiar {
       turnsNeededForFamiliar(option, meatFamiliarEntry)
     );
 
-    if (turnsNeeded < estimatedTurns()) return meatFamiliar();
+    if (turnsNeeded < estimatedTurns()) {
+      return (
+        viableMenu.find((familiar) => familiar.familiar === $familiar`Crimbo Shrub`)?.familiar ??
+        meatFamiliar()
+      );
+    }
   }
 
   if (viableMenu.length === 0) return meatFamiliar();


### PR DESCRIPTION
Also use shrub over meat familiar immediately if ELR is on cooldown and its totalFamiliarValue is > meatFamiliarValue (even if we haven't hit our marginal familiar turncount required yet)