### PR TITLE
Add all wormwood locs to skiplist

### DIFF
--- a/src/wanderer.ts
+++ b/src/wanderer.ts
@@ -98,7 +98,7 @@ const UnlockableZones: UnlockableZone[] = [
 
 function canAdventureOrUnlock(loc: Location) {
   const underwater = loc.environment === "underwater";
-  const skiplist = $locations`The Oasis, The Bubblin' Caldera, Barrrney's Barrr, The F'c'le, The Poop Deck, Belowdecks, 8-Bit Realm, Madness Bakery, The Secret Government Laboratory, The Dire Warren`;
+  const skiplist = $locations`The Oasis, The Bubblin' Caldera, Barrrney's Barrr, The F'c'le, The Poop Deck, Belowdecks, 8-Bit Realm, Madness Bakery, The Secret Government Laboratory, The Dire Warren, The Mouldering Mansion, The Rogue Windmill, The Stately Pleasure Dome`;
   if (!have($item`repaid diaper`) && have($item`Great Wolf's beastly trousers`)) {
     skiplist.push($location`The Icy Peak`);
   }


### PR DESCRIPTION
I have had multiple instances of garbo throwing due to trying to place a wanderer in one of the worm wood locations for a Platinum Guzzlr quest, but hitting a worm wood superlikely (with no combat option) instead. 

Hence this proposal to add them all to the skiplist. 