### PR TITLE
Add Space Jellyfish to familiar actions

### DIFF
--- a/src/combat.ts
+++ b/src/combat.ts
@@ -181,6 +181,9 @@ export class Macro extends StrictMacro {
     ).externalIf(
       canOpenRedPresent() && myFamiliar() === $familiar`Crimbo Shrub`,
       Macro.trySkill($skill`Open a Big Red Present`)
+    ).externalIf(
+      myFamiliar() === $familiar`Space Jellyfish`,
+      Macro.tryHaveSkill($skill`Extract Jelly`)
     );
   }
 

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -178,13 +178,15 @@ export class Macro extends StrictMacro {
     return this.externalIf(
       myFamiliar() === $familiar`Grey Goose` && timeToMeatify(),
       Macro.trySkill($skill`Meatify Matter`)
-    ).externalIf(
-      canOpenRedPresent() && myFamiliar() === $familiar`Crimbo Shrub`,
-      Macro.trySkill($skill`Open a Big Red Present`)
-    ).externalIf(
-      myFamiliar() === $familiar`Space Jellyfish`,
-      Macro.tryHaveSkill($skill`Extract Jelly`)
-    );
+    )
+      .externalIf(
+        canOpenRedPresent() && myFamiliar() === $familiar`Crimbo Shrub`,
+        Macro.trySkill($skill`Open a Big Red Present`)
+      )
+      .externalIf(
+        myFamiliar() === $familiar`Space Jellyfish`,
+        Macro.tryHaveSkill($skill`Extract Jelly`)
+      );
   }
 
   static familiarActions(): Macro {


### PR DESCRIPTION
If we have spacejellyfish as our active familiar, and Macro.familiarActions() is used, attempt to extract jelly