### PR TITLE
Add option to not allow attacking Familiars when choosing Free Fight Fam

### DIFF
--- a/src/familiar/freeFightFamiliar.ts
+++ b/src/familiar/freeFightFamiliar.ts
@@ -77,7 +77,7 @@ export function menu(options: MenuOptions = {}): GeneralFamiliar[] {
   }
 
   if (!allowAttackFamiliars) {
-    familiarMenu.filter((fam) => (fam.familiar.physicalDamage === false && fam.familiar.elementalDamage === false))
+    return familiarMenu.filter((fam) => (fam.familiar.physicalDamage === false && fam.familiar.elementalDamage === false))
   }
 
   return familiarMenu;

--- a/src/familiar/freeFightFamiliar.ts
+++ b/src/familiar/freeFightFamiliar.ts
@@ -84,7 +84,7 @@ export function menu(options: MenuOptions = {}): GeneralFamiliar[] {
 
   if (!allowAttackFamiliars) {
     return familiarMenu.filter(
-      (fam) => fam.familiar.physicalDamage === false && fam.familiar.elementalDamage === false
+      (fam) => !(fam.familiar.physicalDamage || fam.familiar.elementalDamage)
     );
   }
 

--- a/src/familiar/freeFightFamiliar.ts
+++ b/src/familiar/freeFightFamiliar.ts
@@ -13,15 +13,17 @@ type MenuOptions = {
   location?: Location;
   extraFamiliars?: GeneralFamiliar[];
   includeExperienceFamiliars?: boolean;
+  allowAttackFamiliars?: boolean;
 };
 const DEFAULT_MENU_OPTIONS = {
   canChooseMacro: true,
   location: $location`none`,
   extraFamiliars: [],
   includeExperienceFamiliars: true,
+  allowAttackFamiliars: true,
 };
 export function menu(options: MenuOptions = {}): GeneralFamiliar[] {
-  const { includeExperienceFamiliars, canChooseMacro, location, extraFamiliars } = {
+  const { includeExperienceFamiliars, canChooseMacro, location, extraFamiliars, allowAttackFamiliars } = {
     ...DEFAULT_MENU_OPTIONS,
     ...options,
   };
@@ -72,6 +74,10 @@ export function menu(options: MenuOptions = {}): GeneralFamiliar[] {
       leprechaunMultiplier: findLeprechaunMultiplier(meatFam),
       limit: "none",
     });
+  }
+
+  if (!allowAttackFamiliars) {
+    familiarMenu.filter((fam) => (fam.familiar.physicalDamage === false && fam.familiar.elementalDamage === false))
   }
 
   return familiarMenu;

--- a/src/familiar/freeFightFamiliar.ts
+++ b/src/familiar/freeFightFamiliar.ts
@@ -23,7 +23,13 @@ const DEFAULT_MENU_OPTIONS = {
   allowAttackFamiliars: true,
 };
 export function menu(options: MenuOptions = {}): GeneralFamiliar[] {
-  const { includeExperienceFamiliars, canChooseMacro, location, extraFamiliars, allowAttackFamiliars } = {
+  const {
+    includeExperienceFamiliars,
+    canChooseMacro,
+    location,
+    extraFamiliars,
+    allowAttackFamiliars,
+  } = {
     ...DEFAULT_MENU_OPTIONS,
     ...options,
   };
@@ -77,7 +83,9 @@ export function menu(options: MenuOptions = {}): GeneralFamiliar[] {
   }
 
   if (!allowAttackFamiliars) {
-    return familiarMenu.filter((fam) => (fam.familiar.physicalDamage === false && fam.familiar.elementalDamage === false))
+    return familiarMenu.filter(
+      (fam) => fam.familiar.physicalDamage === false && fam.familiar.elementalDamage === false
+    );
   }
 
   return familiarMenu;

--- a/src/yachtzee/lib.ts
+++ b/src/yachtzee/lib.ts
@@ -85,7 +85,8 @@ export function useSpikolodonSpikes(): void {
   const canJelly =
     have($familiar`Space Jellyfish`) && !run.constraints.familiar && realmAvailable("stench");
   const familiar =
-    run.constraints.familiar?.() ?? (canJelly ? $familiar`Space Jellyfish` : freeFightFamiliar({allowAttackFamiliars: false}));
+    run.constraints.familiar?.() ??
+    (canJelly ? $familiar`Space Jellyfish` : freeFightFamiliar({ allowAttackFamiliars: false }));
   useFamiliar(familiar);
   const mergedRequirements = new Requirement([], { forceEquip: $items`Jurassic Parka` }).merge(
     run.constraints.equipmentRequirements?.() ?? new Requirement([], {})

--- a/src/yachtzee/lib.ts
+++ b/src/yachtzee/lib.ts
@@ -85,7 +85,7 @@ export function useSpikolodonSpikes(): void {
   const canJelly =
     have($familiar`Space Jellyfish`) && !run.constraints.familiar && realmAvailable("stench");
   const familiar =
-    run.constraints.familiar?.() ?? (canJelly ? $familiar`Space Jellyfish` : freeFightFamiliar());
+    run.constraints.familiar?.() ?? (canJelly ? $familiar`Space Jellyfish` : freeFightFamiliar({allowAttackFamiliars: false}));
   useFamiliar(familiar);
   const mergedRequirements = new Requirement([], { forceEquip: $items`Jurassic Parka` }).merge(
     run.constraints.equipmentRequirements?.() ?? new Requirement([], {})


### PR DESCRIPTION
Pyacide encountered issue with Garbo spending turns when launching spikes in the Haunted Kitchen as the Cook was killing the monster before they had a chance to run away (presumably when combined with the spikolodon damage).  

To counter this, have added a optional input to freefightfamiliar options of "allowAttackFamiliars", which filters the familiar list if set to false, and set it for the spike launching fam choice.

An option we might want to also consider if moving the default location to a slightly higher ML area just to ensure the 35 dmg doesnt kill them?