### PR TITLE
Revert "Add stone wool as a possible item steal zone"

### DIFF
--- a/src/fights.ts
+++ b/src/fights.ts
@@ -2090,16 +2090,6 @@ const itemStealZones = [
     openCost: () => 0,
     preReq: null,
   },
-  {
-    location: $location`The Hidden Temple`,
-    monster: $monster`baa-relief sheep`,
-    item: $item`stone wool`,
-    dropRate: 1,
-    maximize: ["99 monster level 100 max"], // Sheeps need up to +100 ML to survive the polar vortices
-    isOpen: () => get("lastTempleUnlock") === myAscensions(),
-    openCost: () => 0,
-    preReq: null,
-  },
 ] as ItemStealZone[];
 
 function getBestItemStealZone(): ItemStealZone | null {


### PR DESCRIPTION
Reverts Loathing-Associates-Scripting-Society/garbage-collector#1083

The Hidden Temple is not a 100% combat zone, and we do not currently have any handling for running +combat or for handling the noncombats. This feature is still welcome, but will need support for those issues to be merged again