### PR TITLE
Cache turn count inside the barf turn loop to prevent false positives

### DIFF
--- a/src/barfTurn.ts
+++ b/src/barfTurn.ts
@@ -340,8 +340,6 @@ export default function barfTurn(): void {
   meatMood().execute(estimatedTurns());
   safeRestore();
 
-  const startTurns = totalTurnsPlayed();
-
   const isSober = myInebriety() <= inebrietyLimit();
   const validSobrieties = [Sobriety.EITHER, isSober ? Sobriety.SOBER : Sobriety.DRUNK];
   for (const turn of turns) {
@@ -349,6 +347,7 @@ export default function barfTurn(): void {
       const expectToSpendATurn =
         typeof turn.spendsTurn === "function" ? turn.spendsTurn() : turn.spendsTurn;
 
+      const startTurns = totalTurnsPlayed();
       const success = turn.execute();
       const spentATurn = totalTurnsPlayed() - startTurns === 1;
 


### PR DESCRIPTION
If you encounter an unsuccessful turn for whatever reason, the next will claim to have unexpectedly spent a turn:

Example:
Combat 1: miss sausage goblin
Prints:
```
> We expected to do Guaranteed Kramco, but failed!
> We unexpectedly spent a turn doing Guaranteed Kramco!
```
Combat 2: cast spit acid
Prints:
```
> We unexpectedly spent a turn doing Spit Acid!
```

This fixes the second warning because Spit Acid did not actually cost a turn, the previous combat did.