### PR TITLE
Add `quick` arg to sacrifice optimal behaviors for quicker execution

### DIFF
--- a/mafia/data/garbo_help.json
+++ b/mafia/data/garbo_help.json
@@ -26,6 +26,10 @@
     "description": "*EXPERIMENTAL* garbo only diets after free fights, and attempts to estimate if Yachtzee! chaining is profitable for you - if so, it consumes a specific diet which uses ~30-41 spleen; if not it automatically continues with the regular diet. Requires Spring Break Beach access (it will not grab a one-day pass for you, but will make an attempt if one is used). Sweet Synthesis is strongly recommended, as with access to other meat% buffs from Source Terminal, Fortune Teller, KGB and the summoning chamber. Having access to a PYEC (on hand or in the clan stash) is a plus."
   },
   {
+    "tableItem": "quick",
+    "description": "*EXPERIMENTAL* garbo will sacrifice some optimal behaviors to run quicker. Estimated and actual profits may be less accurate in this mode."
+  },
+  {
     "tableItem": "Note on Arguments:",
     "description": "You can use multiple arguments in conjunction, e.g. \"garbo nobarf ascend\"."
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -283,6 +283,10 @@ export function main(argString = ""): void {
     setAutoAttack(0);
     visitUrl(`account.php?actions[]=flag_aabosses&flag_aabosses=1&action=Update`, true);
 
+    const maximizerCombinationLimit = globalOptions.quickMode
+      ? 50000
+      : get("maximizerCombinationLimit");
+
     propertyManager.set({
       logPreferenceChange: true,
       logPreferenceChangeFilter: [
@@ -325,6 +329,7 @@ export function main(argString = ""): void {
       libramSkillsSoftcore: "none", // Don't cast librams when mana burning, handled manually based on sale price
       valueOfInventory: 2,
       suppressMallPriceCacheMessages: true,
+      maximizerCombinationLimit: maximizerCombinationLimit,
     });
     let bestHalloweiner = 0;
     if (haveInCampground($item`haunted doghouse`)) {
@@ -412,8 +417,16 @@ export function main(argString = ""): void {
         // 1. make an outfit (amulet coin, pantogram, etc), misc other stuff (VYKEA, songboom, robortender drinks)
         dailySetup();
 
+        const preventEquip = $items`broken champagne bottle, Spooky Putty snake, Spooky Putty mitre, Spooky Putty leotard, Spooky Putty ball, papier-mitre, papier-mâchéte, papier-mâchine gun, papier-masque, papier-mâchuridars, smoke ball, stinky fannypack`;
+        if (globalOptions.quickMode) {
+          // Brimstone equipment explodes the number of maximize combinations
+          preventEquip.push(
+            ...$items`Brimstone Bludgeon, Brimstone Bunker, Brimstone Brooch, Brimstone Bracelet, Brimstone Boxers, Brimstone Beret`
+          );
+        }
+
         setDefaultMaximizeOptions({
-          preventEquip: $items`broken champagne bottle, Spooky Putty snake, Spooky Putty mitre, Spooky Putty leotard, Spooky Putty ball, papier-mitre, papier-mâchéte, papier-mâchine gun, papier-masque, papier-mâchuridars, smoke ball, stinky fannypack`,
+          preventEquip: preventEquip,
           preventSlot: $slots`buddy-bjorn, crown-of-thrones`,
         });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -204,8 +204,9 @@ export function main(argString = ""): void {
       if (parsedClanIdOrName) {
         Clan.with(parsedClanIdOrName, () => {
           for (const item of [...stashItems]) {
-            if (getFoldGroup(item).some((item) => have(item)))
+            if (getFoldGroup(item).some((item) => have(item))) {
               cliExecute(`fold ${item}`);
+            }
             const retrieved = retrieveItem(item);
             if (
               item === $item`Spooky Putty sheet` &&
@@ -215,8 +216,9 @@ export function main(argString = ""): void {
               continue;
             }
             print(`Returning ${item} to ${getClanName()} stash.`, HIGHLIGHT);
-            if (putStash(item, 1))
+            if (putStash(item, 1)) {
               stashItems.splice(stashItems.indexOf(item), 1);
+            }
           }
         });
       } else throw new Error("Error: No garbo_stashClan set.");

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,8 +89,7 @@ function ensureBarfAccess() {
 export function canContinue(): boolean {
   return (
     myAdventures() > globalOptions.saveTurns &&
-    (globalOptions.stopTurncount === null ||
-      myTurncount() < globalOptions.stopTurncount)
+    (globalOptions.stopTurncount === null || myTurncount() < globalOptions.stopTurncount)
   );
 }
 
@@ -115,10 +114,7 @@ export function main(argString = ""): void {
     );
   }
 
-  if (
-    !get("garbo_skipAscensionCheck", false) &&
-    (!get("kingLiberated") || myLevel() < 13)
-  ) {
+  if (!get("garbo_skipAscensionCheck", false) && (!get("kingLiberated") || myLevel() < 13)) {
     const proceedRegardless = userConfirmDialog(
       "Looks like your ascension may not be done yet. Running garbo in an unintended character state can result in serious injury and even death. Are you sure you want to garbologize?",
       true
@@ -130,8 +126,7 @@ export function main(argString = ""): void {
 
   if (
     myInebriety() > inebrietyLimit() &&
-    (!have($item`Drunkula's wineglass`) ||
-      !canEquip($item`Drunkula's wineglass`))
+    (!have($item`Drunkula's wineglass`) || !canEquip($item`Drunkula's wineglass`))
   ) {
     throw new Error(
       "Go home, you're drunk. And don't own (or can't equip) Drunkula's wineglass. Consider either being sober or owning Drunkula's wineglass and being able to equip it."
@@ -176,10 +171,7 @@ export function main(argString = ""): void {
     } else if (arg.match(/version/i)) {
       return;
     } else if (arg) {
-      print(
-        `Invalid argument ${arg} passed. Run garbo help to see valid arguments.`,
-        "red"
-      );
+      print(`Invalid argument ${arg} passed. Run garbo help to see valid arguments.`, "red");
       return;
     }
   }
@@ -256,12 +248,10 @@ export function main(argString = ""): void {
   );
   if (
     startingGarden &&
-    !$items`packet of tall grass seeds, packet of mushroom spores`.includes(
-      startingGarden
-    ) &&
+    !$items`packet of tall grass seeds, packet of mushroom spores`.includes(startingGarden) &&
     getCampground()[startingGarden.name] &&
-    $items`packet of tall grass seeds, packet of mushroom spores`.some(
-      (gardenSeed) => have(gardenSeed)
+    $items`packet of tall grass seeds, packet of mushroom spores`.some((gardenSeed) =>
+      have(gardenSeed)
     )
   ) {
     visitUrl("campground.php?action=garden&pwd");
@@ -278,10 +268,7 @@ export function main(argString = ""): void {
   try {
     print("Collecting garbage!", HIGHLIGHT);
     if (globalOptions.stopTurncount !== null) {
-      print(
-        `Stopping in ${globalOptions.stopTurncount - myTurncount()}`,
-        HIGHLIGHT
-      );
+      print(`Stopping in ${globalOptions.stopTurncount - myTurncount()}`, HIGHLIGHT);
     }
     print();
 
@@ -294,10 +281,7 @@ export function main(argString = ""): void {
     }
 
     setAutoAttack(0);
-    visitUrl(
-      `account.php?actions[]=flag_aabosses&flag_aabosses=1&action=Update`,
-      true
-    );
+    visitUrl(`account.php?actions[]=flag_aabosses&flag_aabosses=1&action=Update`, true);
 
     propertyManager.set({
       logPreferenceChange: true,
@@ -348,10 +332,7 @@ export function main(argString = ""): void {
         [
           [$items`bowl of eyeballs, bowl of mummy guts, bowl of maggots`, 1],
           [$items`blood and blood, Jack-O-Lantern beer, zombie`, 2],
-          [
-            $items`wind-up spider, plastic nightmare troll, Telltale™ rubber heart`,
-            3,
-          ],
+          [$items`wind-up spider, plastic nightmare troll, Telltale™ rubber heart`, 3],
         ] as [Item[], number][]
       ).map(([halloweinerOption, choiceId]) => {
         return {
@@ -359,8 +340,7 @@ export function main(argString = ""): void {
           choiceId: choiceId,
         };
       });
-      bestHalloweiner = halloweinerOptions.sort((a, b) => b.price - a.price)[0]
-        .choiceId;
+      bestHalloweiner = halloweinerOptions.sort((a, b) => b.price - a.price)[0].choiceId;
     }
     propertyManager.setChoices({
       1106: 3, // Ghost Dog Chow
@@ -372,10 +352,7 @@ export function main(argString = ""): void {
     if (JuneCleaver.have()) {
       propertyManager.setChoices(
         Object.fromEntries(
-          JuneCleaver.choices.map((choice) => [
-            choice,
-            bestJuneCleaverOption(choice),
-          ])
+          JuneCleaver.choices.map((choice) => [choice, bestJuneCleaverOption(choice)])
         )
       );
     }
@@ -420,18 +397,14 @@ export function main(argString = ""): void {
     withStash(stashItems, () => {
       withVIPClan(() => {
         // 0. diet stuff.
-        if (
-          globalOptions.noDiet ||
-          get("_garboYachtzeeChainCompleted", false)
-        ) {
+        if (globalOptions.noDiet || get("_garboYachtzeeChainCompleted", false)) {
           print("We should not be yachtzee chaining", "red");
           globalOptions.yachtzeeChain = false;
         }
 
         if (
           !globalOptions.noDiet &&
-          (!globalOptions.yachtzeeChain ||
-            get("_garboYachtzeeChainCompleted", false))
+          (!globalOptions.yachtzeeChain || get("_garboYachtzeeChainCompleted", false))
         ) {
           runDiet();
         }
@@ -482,14 +455,8 @@ export function main(argString = ""): void {
     });
   } finally {
     propertyManager.resetAll();
-    set(
-      "garboStashItems",
-      stashItems.map((item) => toInt(item).toFixed(0)).join(",")
-    );
-    visitUrl(
-      `account.php?actions[]=flag_aabosses&flag_aabosses=${aaBossFlag}&action=Update`,
-      true
-    );
+    set("garboStashItems", stashItems.map((item) => toInt(item).toFixed(0)).join(","));
+    visitUrl(`account.php?actions[]=flag_aabosses&flag_aabosses=${aaBossFlag}&action=Update`, true);
     if (startingGarden && have(startingGarden)) use(startingGarden);
     printEmbezzlerLog();
     printGarboSession();

--- a/src/index.ts
+++ b/src/index.ts
@@ -284,7 +284,7 @@ export function main(argString = ""): void {
     visitUrl(`account.php?actions[]=flag_aabosses&flag_aabosses=1&action=Update`, true);
 
     const maximizerCombinationLimit = globalOptions.quickMode
-      ? 50000
+      ? 100000
       : get("maximizerCombinationLimit");
 
     propertyManager.set({

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,8 @@ function ensureBarfAccess() {
 export function canContinue(): boolean {
   return (
     myAdventures() > globalOptions.saveTurns &&
-    (globalOptions.stopTurncount === null || myTurncount() < globalOptions.stopTurncount)
+    (globalOptions.stopTurncount === null ||
+      myTurncount() < globalOptions.stopTurncount)
   );
 }
 
@@ -114,7 +115,10 @@ export function main(argString = ""): void {
     );
   }
 
-  if (!get("garbo_skipAscensionCheck", false) && (!get("kingLiberated") || myLevel() < 13)) {
+  if (
+    !get("garbo_skipAscensionCheck", false) &&
+    (!get("kingLiberated") || myLevel() < 13)
+  ) {
     const proceedRegardless = userConfirmDialog(
       "Looks like your ascension may not be done yet. Running garbo in an unintended character state can result in serious injury and even death. Are you sure you want to garbologize?",
       true
@@ -126,7 +130,8 @@ export function main(argString = ""): void {
 
   if (
     myInebriety() > inebrietyLimit() &&
-    (!have($item`Drunkula's wineglass`) || !canEquip($item`Drunkula's wineglass`))
+    (!have($item`Drunkula's wineglass`) ||
+      !canEquip($item`Drunkula's wineglass`))
   ) {
     throw new Error(
       "Go home, you're drunk. And don't own (or can't equip) Drunkula's wineglass. Consider either being sober or owning Drunkula's wineglass and being able to equip it."
@@ -166,10 +171,15 @@ export function main(argString = ""): void {
       globalOptions.noDiet = true;
     } else if (arg.match(/yachtzeechain/)) {
       globalOptions.yachtzeeChain = true;
+    } else if (arg.match(/quick/)) {
+      globalOptions.quickMode = true;
     } else if (arg.match(/version/i)) {
       return;
     } else if (arg) {
-      print(`Invalid argument ${arg} passed. Run garbo help to see valid arguments.`, "red");
+      print(
+        `Invalid argument ${arg} passed. Run garbo help to see valid arguments.`,
+        "red"
+      );
       return;
     }
   }
@@ -194,7 +204,8 @@ export function main(argString = ""): void {
       if (parsedClanIdOrName) {
         Clan.with(parsedClanIdOrName, () => {
           for (const item of [...stashItems]) {
-            if (getFoldGroup(item).some((item) => have(item))) cliExecute(`fold ${item}`);
+            if (getFoldGroup(item).some((item) => have(item)))
+              cliExecute(`fold ${item}`);
             const retrieved = retrieveItem(item);
             if (
               item === $item`Spooky Putty sheet` &&
@@ -204,7 +215,8 @@ export function main(argString = ""): void {
               continue;
             }
             print(`Returning ${item} to ${getClanName()} stash.`, HIGHLIGHT);
-            if (putStash(item, 1)) stashItems.splice(stashItems.indexOf(item), 1);
+            if (putStash(item, 1))
+              stashItems.splice(stashItems.indexOf(item), 1);
           }
         });
       } else throw new Error("Error: No garbo_stashClan set.");
@@ -242,10 +254,12 @@ export function main(argString = ""): void {
   );
   if (
     startingGarden &&
-    !$items`packet of tall grass seeds, packet of mushroom spores`.includes(startingGarden) &&
+    !$items`packet of tall grass seeds, packet of mushroom spores`.includes(
+      startingGarden
+    ) &&
     getCampground()[startingGarden.name] &&
-    $items`packet of tall grass seeds, packet of mushroom spores`.some((gardenSeed) =>
-      have(gardenSeed)
+    $items`packet of tall grass seeds, packet of mushroom spores`.some(
+      (gardenSeed) => have(gardenSeed)
     )
   ) {
     visitUrl("campground.php?action=garden&pwd");
@@ -262,7 +276,10 @@ export function main(argString = ""): void {
   try {
     print("Collecting garbage!", HIGHLIGHT);
     if (globalOptions.stopTurncount !== null) {
-      print(`Stopping in ${globalOptions.stopTurncount - myTurncount()}`, HIGHLIGHT);
+      print(
+        `Stopping in ${globalOptions.stopTurncount - myTurncount()}`,
+        HIGHLIGHT
+      );
     }
     print();
 
@@ -275,7 +292,10 @@ export function main(argString = ""): void {
     }
 
     setAutoAttack(0);
-    visitUrl(`account.php?actions[]=flag_aabosses&flag_aabosses=1&action=Update`, true);
+    visitUrl(
+      `account.php?actions[]=flag_aabosses&flag_aabosses=1&action=Update`,
+      true
+    );
 
     propertyManager.set({
       logPreferenceChange: true,
@@ -326,12 +346,19 @@ export function main(argString = ""): void {
         [
           [$items`bowl of eyeballs, bowl of mummy guts, bowl of maggots`, 1],
           [$items`blood and blood, Jack-O-Lantern beer, zombie`, 2],
-          [$items`wind-up spider, plastic nightmare troll, Telltale™ rubber heart`, 3],
+          [
+            $items`wind-up spider, plastic nightmare troll, Telltale™ rubber heart`,
+            3,
+          ],
         ] as [Item[], number][]
       ).map(([halloweinerOption, choiceId]) => {
-        return { price: garboAverageValue(...halloweinerOption), choiceId: choiceId };
+        return {
+          price: garboAverageValue(...halloweinerOption),
+          choiceId: choiceId,
+        };
       });
-      bestHalloweiner = halloweinerOptions.sort((a, b) => b.price - a.price)[0].choiceId;
+      bestHalloweiner = halloweinerOptions.sort((a, b) => b.price - a.price)[0]
+        .choiceId;
     }
     propertyManager.setChoices({
       1106: 3, // Ghost Dog Chow
@@ -343,7 +370,10 @@ export function main(argString = ""): void {
     if (JuneCleaver.have()) {
       propertyManager.setChoices(
         Object.fromEntries(
-          JuneCleaver.choices.map((choice) => [choice, bestJuneCleaverOption(choice)])
+          JuneCleaver.choices.map((choice) => [
+            choice,
+            bestJuneCleaverOption(choice),
+          ])
         )
       );
     }
@@ -388,14 +418,18 @@ export function main(argString = ""): void {
     withStash(stashItems, () => {
       withVIPClan(() => {
         // 0. diet stuff.
-        if (globalOptions.noDiet || get("_garboYachtzeeChainCompleted", false)) {
+        if (
+          globalOptions.noDiet ||
+          get("_garboYachtzeeChainCompleted", false)
+        ) {
           print("We should not be yachtzee chaining", "red");
           globalOptions.yachtzeeChain = false;
         }
 
         if (
           !globalOptions.noDiet &&
-          (!globalOptions.yachtzeeChain || get("_garboYachtzeeChainCompleted", false))
+          (!globalOptions.yachtzeeChain ||
+            get("_garboYachtzeeChainCompleted", false))
         ) {
           runDiet();
         }
@@ -446,8 +480,14 @@ export function main(argString = ""): void {
     });
   } finally {
     propertyManager.resetAll();
-    set("garboStashItems", stashItems.map((item) => toInt(item).toFixed(0)).join(","));
-    visitUrl(`account.php?actions[]=flag_aabosses&flag_aabosses=${aaBossFlag}&action=Update`, true);
+    set(
+      "garboStashItems",
+      stashItems.map((item) => toInt(item).toFixed(0)).join(",")
+    );
+    visitUrl(
+      `account.php?actions[]=flag_aabosses&flag_aabosses=${aaBossFlag}&action=Update`,
+      true
+    );
     if (startingGarden && have(startingGarden)) use(startingGarden);
     printEmbezzlerLog();
     printGarboSession();

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -202,8 +202,9 @@ export function mapMonster(location: Location, monster: Monster): void {
   const fightPage = visitUrl(
     `choice.php?pwd&whichchoice=1435&option=1&heyscriptswhatsupwinkwink=${monster.id}`
   );
-  if (!fightPage.includes(monster.name))
+  if (!fightPage.includes(monster.name)) {
     throw "Something went wrong starting the fight.";
+  }
 }
 
 export function argmax<T>(values: [T, number][]): T {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -117,8 +117,7 @@ export const propertyManager = new PropertiesManager();
 export const baseMeat =
   SongBoom.have() &&
   (SongBoom.songChangesLeft() > 0 ||
-    (SongBoom.song() === "Total Eclipse of Your Meat" &&
-      myInebriety() <= inebrietyLimit()))
+    (SongBoom.song() === "Total Eclipse of Your Meat" && myInebriety() <= inebrietyLimit()))
     ? 275
     : 250;
 
@@ -220,8 +219,7 @@ export function argmax<T>(values: [T, number][]): T {
  */
 export function arrayEquals<T>(array1: T[], array2: T[]): boolean {
   return (
-    array1.length === array2.length &&
-    array1.every((element, index) => element === array2[index])
+    array1.length === array2.length && array1.every((element, index) => element === array2[index])
   );
 }
 
@@ -303,9 +301,7 @@ export function printHelpMenu(): void {
     return `<tr><td width=200><pre> ${tableItem}</pre></td><td width=600><pre>${croppedDescription}</pre></td></tr>`;
   });
   printHtml(
-    `<table border=2 width=800 style="font-family:monospace;">${tableRows.join(
-      ``
-    )}</table>`
+    `<table border=2 width=800 style="font-family:monospace;">${tableRows.join(``)}</table>`
   );
 }
 
@@ -364,9 +360,7 @@ export function safeRestoreMpTarget(): number {
 
 export function safeRestore(): void {
   if (have($effect`Beaten Up`)) {
-    if (
-      get("lastEncounter") === "Sssshhsssblllrrggghsssssggggrrgglsssshhssslblgl"
-    ) {
+    if (get("lastEncounter") === "Sssshhsssblllrrggghsssssggggrrgglsssshhssslblgl") {
       uneffect($effect`Beaten Up`);
     } else {
       throw new Error(
@@ -398,28 +392,17 @@ export function checkGithubVersion(): void {
   if (process.env.GITHUB_REPOSITORY === "CustomBuild") {
     print("Skipping version check for custom build");
   } else {
-    if (
-      gitAtHead(
-        "Loathing-Associates-Scripting-Society-garbage-collector-release"
-      )
-    ) {
+    if (gitAtHead("Loathing-Associates-Scripting-Society-garbage-collector-release")) {
       print("Garbo is up to date!", HIGHLIGHT);
     } else {
-      const gitBranches: { name: string; commit: { sha: string } }[] =
-        JSON.parse(
-          visitUrl(
-            `https://api.github.com/repos/${process.env.GITHUB_REPOSITORY}/branches`
-          )
-        );
-      const releaseCommit = gitBranches.find(
-        (branchInfo) => branchInfo.name === "release"
-      )?.commit;
+      const gitBranches: { name: string; commit: { sha: string } }[] = JSON.parse(
+        visitUrl(`https://api.github.com/repos/${process.env.GITHUB_REPOSITORY}/branches`)
+      );
+      const releaseCommit = gitBranches.find((branchInfo) => branchInfo.name === "release")?.commit;
       print("Garbo is out of date. Please run 'git update!'", "red");
       print(
         `Local Version: ${
-          gitInfo(
-            "Loathing-Associates-Scripting-Society-garbage-collector-release"
-          ).commit
+          gitInfo("Loathing-Associates-Scripting-Society-garbage-collector-release").commit
         }.`
       );
       print(`Release Version: ${releaseCommit}.`);
@@ -428,24 +411,14 @@ export function checkGithubVersion(): void {
 }
 
 export function realmAvailable(
-  identifier:
-    | "spooky"
-    | "stench"
-    | "hot"
-    | "cold"
-    | "sleaze"
-    | "fantasy"
-    | "pirate"
+  identifier: "spooky" | "stench" | "hot" | "cold" | "sleaze" | "fantasy" | "pirate"
 ): boolean {
   if (identifier === "fantasy") {
     return get(`_frToday`) || get(`frAlways`);
   } else if (identifier === "pirate") {
     return get(`_prToday`) || get(`prAlways`);
   }
-  return (
-    get(`_${identifier}AirportToday`, false) ||
-    get(`${identifier}AirportAlways`, false)
-  );
+  return get(`_${identifier}AirportToday`, false) || get(`${identifier}AirportAlways`, false);
 }
 
 export function formatNumber(num: number): string {
@@ -471,11 +444,7 @@ export function getChoiceOption(partialText: string): number {
  * @param timeOut time to show dialog before submitting default value
  * @returns answer to confirmation dialog
  */
-export function userConfirmDialog(
-  msg: string,
-  defaultValue: boolean,
-  timeOut?: number
-): boolean {
+export function userConfirmDialog(msg: string, defaultValue: boolean, timeOut?: number): boolean {
   if (get("garbo_autoUserConfirm", false)) {
     print(`Automatically selected ${defaultValue} for ${msg}`, "red");
     return defaultValue;
@@ -489,13 +458,11 @@ export const latteActionSourceFinderConstraints = {
   allowedAction: (action: ActionSource): boolean => {
     if (!have($item`latte lovers member's mug`)) return true;
     const forceEquipsOtherThanLatte = (
-      action?.constraints?.equipmentRequirements?.().maximizeOptions
-        .forceEquip ?? []
+      action?.constraints?.equipmentRequirements?.().maximizeOptions.forceEquip ?? []
     ).filter((equipment) => equipment !== $item`latte lovers member's mug`);
     return (
-      forceEquipsOtherThanLatte.every(
-        (equipment) => toSlot(equipment) !== $slot`off-hand`
-      ) && sum(forceEquipsOtherThanLatte, weaponHands) < 2
+      forceEquipsOtherThanLatte.every((equipment) => toSlot(equipment) !== $slot`off-hand`) &&
+      sum(forceEquipsOtherThanLatte, weaponHands) < 2
     );
   },
 };
@@ -515,8 +482,7 @@ const touristFamilyRatio = touristFamilies / barfTourists;
 // Estimate number of turns till the counter hits 27
 // then estimate the expected number of turns required to hit a counter of >= 30
 export const turnsToNC =
-  (27 * barfTourists) /
-    (garbageTourists + angryTourists + 3 * touristFamilies) +
+  (27 * barfTourists) / (garbageTourists + angryTourists + 3 * touristFamilies) +
   1 * touristFamilyRatio +
   2 * (1 - touristFamilyRatio) * touristFamilyRatio +
   3 * (1 - touristFamilyRatio) * (1 - touristFamilyRatio);
@@ -555,9 +521,7 @@ export function valueJuneCleaverOption(result: Item | number): number {
   return result instanceof Item ? garboValue(result) : result;
 }
 
-export function bestJuneCleaverOption(
-  id: typeof JuneCleaver.choices[number]
-): 1 | 2 | 3 {
+export function bestJuneCleaverOption(id: typeof JuneCleaver.choices[number]): 1 | 2 | 3 {
   const options = [1, 2, 3] as const;
   return options
     .map((option) => ({

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -90,6 +90,7 @@ export const globalOptions: {
   noDiet: boolean;
   clarasBellClaimed: boolean;
   yachtzeeChain: boolean;
+  quickMode: boolean;
 } = {
   stopTurncount: null,
   ascending: false,
@@ -102,6 +103,7 @@ export const globalOptions: {
   noDiet: false,
   clarasBellClaimed: get("_claraBellUsed"),
   yachtzeeChain: false,
+  quickMode: false,
 };
 
 export type BonusEquipMode = "free" | "embezzler" | "dmt" | "barf";
@@ -115,7 +117,8 @@ export const propertyManager = new PropertiesManager();
 export const baseMeat =
   SongBoom.have() &&
   (SongBoom.songChangesLeft() > 0 ||
-    (SongBoom.song() === "Total Eclipse of Your Meat" && myInebriety() <= inebrietyLimit()))
+    (SongBoom.song() === "Total Eclipse of Your Meat" &&
+      myInebriety() <= inebrietyLimit()))
     ? 275
     : 250;
 
@@ -199,7 +202,8 @@ export function mapMonster(location: Location, monster: Monster): void {
   const fightPage = visitUrl(
     `choice.php?pwd&whichchoice=1435&option=1&heyscriptswhatsupwinkwink=${monster.id}`
   );
-  if (!fightPage.includes(monster.name)) throw "Something went wrong starting the fight.";
+  if (!fightPage.includes(monster.name))
+    throw "Something went wrong starting the fight.";
 }
 
 export function argmax<T>(values: [T, number][]): T {
@@ -215,7 +219,8 @@ export function argmax<T>(values: [T, number][]): T {
  */
 export function arrayEquals<T>(array1: T[], array2: T[]): boolean {
   return (
-    array1.length === array2.length && array1.every((element, index) => element === array2[index])
+    array1.length === array2.length &&
+    array1.every((element, index) => element === array2[index])
   );
 }
 
@@ -297,7 +302,9 @@ export function printHelpMenu(): void {
     return `<tr><td width=200><pre> ${tableItem}</pre></td><td width=600><pre>${croppedDescription}</pre></td></tr>`;
   });
   printHtml(
-    `<table border=2 width=800 style="font-family:monospace;">${tableRows.join(``)}</table>`
+    `<table border=2 width=800 style="font-family:monospace;">${tableRows.join(
+      ``
+    )}</table>`
   );
 }
 
@@ -356,7 +363,9 @@ export function safeRestoreMpTarget(): number {
 
 export function safeRestore(): void {
   if (have($effect`Beaten Up`)) {
-    if (get("lastEncounter") === "Sssshhsssblllrrggghsssssggggrrgglsssshhssslblgl") {
+    if (
+      get("lastEncounter") === "Sssshhsssblllrrggghsssssggggrrgglsssshhssslblgl"
+    ) {
       uneffect($effect`Beaten Up`);
     } else {
       throw new Error(
@@ -388,17 +397,28 @@ export function checkGithubVersion(): void {
   if (process.env.GITHUB_REPOSITORY === "CustomBuild") {
     print("Skipping version check for custom build");
   } else {
-    if (gitAtHead("Loathing-Associates-Scripting-Society-garbage-collector-release")) {
+    if (
+      gitAtHead(
+        "Loathing-Associates-Scripting-Society-garbage-collector-release"
+      )
+    ) {
       print("Garbo is up to date!", HIGHLIGHT);
     } else {
-      const gitBranches: { name: string; commit: { sha: string } }[] = JSON.parse(
-        visitUrl(`https://api.github.com/repos/${process.env.GITHUB_REPOSITORY}/branches`)
-      );
-      const releaseCommit = gitBranches.find((branchInfo) => branchInfo.name === "release")?.commit;
+      const gitBranches: { name: string; commit: { sha: string } }[] =
+        JSON.parse(
+          visitUrl(
+            `https://api.github.com/repos/${process.env.GITHUB_REPOSITORY}/branches`
+          )
+        );
+      const releaseCommit = gitBranches.find(
+        (branchInfo) => branchInfo.name === "release"
+      )?.commit;
       print("Garbo is out of date. Please run 'git update!'", "red");
       print(
         `Local Version: ${
-          gitInfo("Loathing-Associates-Scripting-Society-garbage-collector-release").commit
+          gitInfo(
+            "Loathing-Associates-Scripting-Society-garbage-collector-release"
+          ).commit
         }.`
       );
       print(`Release Version: ${releaseCommit}.`);
@@ -407,14 +427,24 @@ export function checkGithubVersion(): void {
 }
 
 export function realmAvailable(
-  identifier: "spooky" | "stench" | "hot" | "cold" | "sleaze" | "fantasy" | "pirate"
+  identifier:
+    | "spooky"
+    | "stench"
+    | "hot"
+    | "cold"
+    | "sleaze"
+    | "fantasy"
+    | "pirate"
 ): boolean {
   if (identifier === "fantasy") {
     return get(`_frToday`) || get(`frAlways`);
   } else if (identifier === "pirate") {
     return get(`_prToday`) || get(`prAlways`);
   }
-  return get(`_${identifier}AirportToday`, false) || get(`${identifier}AirportAlways`, false);
+  return (
+    get(`_${identifier}AirportToday`, false) ||
+    get(`${identifier}AirportAlways`, false)
+  );
 }
 
 export function formatNumber(num: number): string {
@@ -440,7 +470,11 @@ export function getChoiceOption(partialText: string): number {
  * @param timeOut time to show dialog before submitting default value
  * @returns answer to confirmation dialog
  */
-export function userConfirmDialog(msg: string, defaultValue: boolean, timeOut?: number): boolean {
+export function userConfirmDialog(
+  msg: string,
+  defaultValue: boolean,
+  timeOut?: number
+): boolean {
   if (get("garbo_autoUserConfirm", false)) {
     print(`Automatically selected ${defaultValue} for ${msg}`, "red");
     return defaultValue;
@@ -454,11 +488,13 @@ export const latteActionSourceFinderConstraints = {
   allowedAction: (action: ActionSource): boolean => {
     if (!have($item`latte lovers member's mug`)) return true;
     const forceEquipsOtherThanLatte = (
-      action?.constraints?.equipmentRequirements?.().maximizeOptions.forceEquip ?? []
+      action?.constraints?.equipmentRequirements?.().maximizeOptions
+        .forceEquip ?? []
     ).filter((equipment) => equipment !== $item`latte lovers member's mug`);
     return (
-      forceEquipsOtherThanLatte.every((equipment) => toSlot(equipment) !== $slot`off-hand`) &&
-      sum(forceEquipsOtherThanLatte, weaponHands) < 2
+      forceEquipsOtherThanLatte.every(
+        (equipment) => toSlot(equipment) !== $slot`off-hand`
+      ) && sum(forceEquipsOtherThanLatte, weaponHands) < 2
     );
   },
 };
@@ -478,7 +514,8 @@ const touristFamilyRatio = touristFamilies / barfTourists;
 // Estimate number of turns till the counter hits 27
 // then estimate the expected number of turns required to hit a counter of >= 30
 export const turnsToNC =
-  (27 * barfTourists) / (garbageTourists + angryTourists + 3 * touristFamilies) +
+  (27 * barfTourists) /
+    (garbageTourists + angryTourists + 3 * touristFamilies) +
   1 * touristFamilyRatio +
   2 * (1 - touristFamilyRatio) * touristFamilyRatio +
   3 * (1 - touristFamilyRatio) * (1 - touristFamilyRatio);
@@ -517,7 +554,9 @@ export function valueJuneCleaverOption(result: Item | number): number {
   return result instanceof Item ? garboValue(result) : result;
 }
 
-export function bestJuneCleaverOption(id: typeof JuneCleaver.choices[number]): 1 | 2 | 3 {
+export function bestJuneCleaverOption(
+  id: typeof JuneCleaver.choices[number]
+): 1 | 2 | 3 {
   const options = [1, 2, 3] as const;
   return options
     .map((option) => ({

--- a/src/session.ts
+++ b/src/session.ts
@@ -155,6 +155,7 @@ function printSession(session: Session): void {
   printProfit(highValue);
   print(` You lost meat on ${lowValue.length} items including:`);
   printProfit(lowValue);
+  print(`Quick mode was enabled, results may be less accurate than normal.`);
 }
 
 function garboSaleValue(item: Item) {

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,4 +1,5 @@
 import {
+  autosellPrice,
   Coinmaster,
   historicalAge,
   historicalPrice,

--- a/src/session.ts
+++ b/src/session.ts
@@ -161,7 +161,8 @@ function printSession(session: Session): void {
 function garboSaleValue(item: Item) {
   if (globalOptions.quickMode) {
     if (historicalAge(item) <= 7.0 && historicalPrice(item) > 0) {
-      return historicalPrice(item) * 0.9;
+      const isMallMin = historicalPrice(item) === Math.max(100, 2 * autosellPrice(item));
+      return isMallMin ? autosellPrice(item) : 0.9 * historicalPrice(item);
     }
   }
   return getSaleValue(item);

--- a/src/session.ts
+++ b/src/session.ts
@@ -236,4 +236,5 @@ export function printGarboSession(): void {
 
   message("This run of garbo", meat, items);
   message("So far today", totalMeat, totalItems);
+  print("Quick mode was enabled, results may be less accurate than normal.");
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -7,21 +7,8 @@ import {
   sellPrice,
   toInt,
 } from "kolmafia";
-import {
-  $item,
-  $items,
-  getSaleValue,
-  property,
-  Session,
-  set,
-  sumNumbers,
-} from "libram";
-import {
-  formatNumber,
-  globalOptions,
-  HIGHLIGHT,
-  resetDailyPreference,
-} from "./lib";
+import { $item, $items, getSaleValue, property, Session, set, sumNumbers } from "libram";
+import { formatNumber, globalOptions, HIGHLIGHT, resetDailyPreference } from "./lib";
 
 function currency(...items: Item[]): () => number {
   const unitCost: [Item, number][] = items.map((i) => {
@@ -32,8 +19,7 @@ function currency(...items: Item[]): () => number {
       return [i, sellPrice(coinmaster, i)];
     }
   });
-  return () =>
-    Math.max(...unitCost.map(([item, cost]) => garboValue(item) / cost));
+  return () => Math.max(...unitCost.map(([item, cost]) => garboValue(item) / cost));
 }
 
 function complexCandy(): [Item, () => number][] {
@@ -48,31 +34,20 @@ function complexCandy(): [Item, () => number][] {
   }
   const candyIdPrices: [Item, () => number][] = candies
     .filter((i) => !i.tradeable)
-    .map((i) => [
-      i,
-      () => Math.min(...candyLookup[toInt(i) % 5].map((i) => garboValue(i))),
-    ]);
+    .map((i) => [i, () => Math.min(...candyLookup[toInt(i) % 5].map((i) => garboValue(i)))]);
   return candyIdPrices;
 }
 
 const specialValueLookup = new Map<Item, () => number>([
   [
     $item`Freddy Kruegerand`,
-    currency(
-      ...$items`bottle of Bloodweiser, electric Kool-Aid, Dreadsylvanian skeleton key`
-    ),
+    currency(...$items`bottle of Bloodweiser, electric Kool-Aid, Dreadsylvanian skeleton key`),
   ],
   [$item`Beach Buck`, currency($item`one-day ticket to Spring Break Beach`)],
-  [
-    $item`Coinspiracy`,
-    currency(...$items`Merc Core deployment orders, karma shawarma`),
-  ],
+  [$item`Coinspiracy`, currency(...$items`Merc Core deployment orders, karma shawarma`)],
   [$item`FunFunds™`, currency($item`one-day ticket to Dinseylandfill`)],
   [$item`Volcoino`, currency($item`one-day ticket to That 70s Volcano`)],
-  [
-    $item`Wal-Mart gift certificate`,
-    currency($item`one-day ticket to The Glaciest`),
-  ],
+  [$item`Wal-Mart gift certificate`, currency($item`one-day ticket to The Glaciest`)],
   [$item`Rubee™`, currency($item`FantasyRealm guest pass`)],
   [$item`Guzzlrbuck`, currency($item`Never Don't Stop Not Striving`)],
   ...complexCandy(),
@@ -86,8 +61,7 @@ const specialValueLookup = new Map<Item, () => number>([
       3 *
       Math.max(
         garboValue($item`mushroom tea`) - garboValue($item`soda water`),
-        garboValue($item`mushroom whiskey`) -
-          garboValue($item`fermenting powder`),
+        garboValue($item`mushroom whiskey`) - garboValue($item`fermenting powder`),
         garboValue($item`mushroom filet`)
       ),
   ],
@@ -114,10 +88,7 @@ const specialValueLookup = new Map<Item, () => number>([
   ],
   [
     $item`weathered barrel`,
-    () =>
-      garboAverageValue(
-        ...$items`bean burrito, enchanted bean burrito, jumping bean burrito`
-      ),
+    () => garboAverageValue(...$items`bean burrito, enchanted bean burrito, jumping bean burrito`),
   ],
   [
     $item`dusty barrel`,
@@ -166,9 +137,7 @@ const specialValueLookup = new Map<Item, () => number>([
 
 function printSession(session: Session): void {
   const value = session.value(garboValue);
-  const printProfit = (
-    details: { item: Item; value: number; quantity: number }[]
-  ) => {
+  const printProfit = (details: { item: Item; value: number; quantity: number }[]) => {
     for (const { item, quantity, value } of details) {
       print(`  ${item} (${quantity}) @ ${Math.floor(value)}`);
     }
@@ -181,9 +150,7 @@ function printSession(session: Session): void {
     .sort((a, b) => b.value - a.value);
 
   print(`Total Session Value: ${value.total}`);
-  print(
-    `Of that, ${value.meat} came from meat and ${value.items} came from items`
-  );
+  print(`Of that, ${value.meat} came from meat and ${value.items} came from items`);
   print(` You gained meat on ${highValue.length} items including:`);
   printProfit(highValue);
   print(` You lost meat on ${lowValue.length} items including:`);
@@ -204,9 +171,7 @@ export function garboValue(item: Item): number {
   const cachedValue = garboValueCache.get(item);
   if (cachedValue === undefined) {
     const specialValueCompute = specialValueLookup.get(item);
-    const value = specialValueCompute
-      ? specialValueCompute()
-      : garboSaleValue(item);
+    const value = specialValueCompute ? specialValueCompute() : garboSaleValue(item);
     garboValueCache.set(item, value);
     return value;
   }
@@ -247,11 +212,9 @@ export function printGarboSession(): void {
   }
   const message = (head: string, meat: number, items: number) =>
     print(
-      `${head}, you generated ${formatNumber(
-        meat + items
-      )} meat, with ${formatNumber(meat)} raw meat and ${formatNumber(
-        items
-      )} from items`,
+      `${head}, you generated ${formatNumber(meat + items)} meat, with ${formatNumber(
+        meat
+      )} raw meat and ${formatNumber(items)} from items`,
       HIGHLIGHT
     );
 
@@ -264,12 +227,7 @@ export function printGarboSession(): void {
   const winners = itemDetails.sort((a, b) => b.value - a.value).slice(0, 3);
   print(`Extreme Items:`, HIGHLIGHT);
   for (const detail of [...winners, ...losers]) {
-    print(
-      `${detail.quantity} ${detail.item} worth ${detail.value.toFixed(
-        0
-      )} total`,
-      HIGHLIGHT
-    );
+    print(`${detail.quantity} ${detail.item} worth ${detail.value.toFixed(0)} total`, HIGHLIGHT);
   }
 
   set("garboResultsMeat", totalMeat);

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,8 +1,8 @@
 import {
   Coinmaster,
-  Item,
   historicalAge,
   historicalPrice,
+  Item,
   print,
   sellPrice,
   toInt,


### PR DESCRIPTION
Only change currently is to instead use historical price rather than getSalePrice if the prices are less than a week old, for only items that will be sold.