### PR TITLE
Fix olfaction

### DIFF
--- a/src/combat.ts
+++ b/src/combat.ts
@@ -296,9 +296,8 @@ export class Macro extends StrictMacro {
       )
       .externalIf(
         have($skill`Transcendent Olfaction`) &&
-          property.getString("olfactedMonster") !== "garbage tourist" &&
-          get("_olfactionsUsed") < 3 &&
-          !have($effect`On the Trail`),
+          (get("olfactedMonster") !== $monster`garbage tourist` || !have($effect`On the Trail`)) &&
+          get("_olfactionsUsed") < 3,
         Macro.if_($monster`garbage tourist`, Macro.trySkill($skill`Transcendent Olfaction`))
       )
       .externalIf(

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -297,7 +297,8 @@ export class Macro extends StrictMacro {
       .externalIf(
         have($skill`Transcendent Olfaction`) &&
           property.getString("olfactedMonster") !== "garbage tourist" &&
-          get("_olfactionsUsed") < 3 && have($effect"On the Trail"),
+          get("_olfactionsUsed") < 3 &&
+          !have($effect`On the Trail`),
         Macro.if_($monster`garbage tourist`, Macro.trySkill($skill`Transcendent Olfaction`))
       )
       .externalIf(

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -49,7 +49,6 @@ import {
   get,
   getTodaysHolidayWanderers,
   have,
-  property,
   SourceTerminal,
   StrictMacro,
 } from "libram";

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -297,7 +297,7 @@ export class Macro extends StrictMacro {
       .externalIf(
         have($skill`Transcendent Olfaction`) &&
           property.getString("olfactedMonster") !== "garbage tourist" &&
-          get("_olfactionsUsed") < 3,
+          get("_olfactionsUsed") < 3 && have($effect"On the Trail"),
         Macro.if_($monster`garbage tourist`, Macro.trySkill($skill`Transcendent Olfaction`))
       )
       .externalIf(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import {
   availableAmount,
   buy,
+  canEquip,
   cliExecute,
   getCampground,
   getClanName,
@@ -121,6 +122,15 @@ export function main(argString = ""): void {
     if (!proceedRegardless) {
       throw new Error("User interrupt requested. Stopping Garbage Collector.");
     }
+  }
+
+  if (
+    myInebriety() > inebrietyLimit() &&
+    (!have($item`Drunkula's wineglass`) || !canEquip($item`Drunkula's wineglass`))
+  ) {
+    throw new Error(
+      "Go home, you're drunk. And don't own (or can't equip) Drunkula's wineglass. Consider either being sober or owning Drunkula's wineglass and being able to equip it."
+    );
   }
 
   if (get("valueOfAdventure") <= 3500) {


### PR DESCRIPTION
The property "olfactedMonster" is not reset on ascension, so we're not currently casting olfaction if we're ascending and not casting olfaction on something else (ie glooping)