### PR TITLE
add option to restrict bestConsumable by levelreq

### DIFF
--- a/src/diet.ts
+++ b/src/diet.ts
@@ -381,8 +381,9 @@ function menu(): MenuItem<Note>[] {
 
 export function bestConsumable(
   organType: "booze" | "food" | "spleen",
+  levelRestrict = true,
   restrictList?: Item | Item[],
-  maxSize?: number
+  maxSize?: number,
 ): { edible: Item; value: number } {
   const fullMenu = potionMenu(menu(), 0, 0);
   let organMenu = fullMenu.filter((menuItem) => itemType(menuItem.item) === organType);
@@ -394,7 +395,10 @@ export function bestConsumable(
     }
   }
   if (maxSize) {
-    organMenu = organMenu.filter((MenuItem) => MenuItem.size <= maxSize);
+    organMenu = organMenu.filter((menuItem) => menuItem.size <= maxSize);
+  }
+  if (levelRestrict) {
+    organMenu = organMenu.filter((menuItem) => menuItem.item.levelreq <= myLevel());
   }
   const organList = organMenu.map((consumable) => {
     const edible = consumable.item;

--- a/src/diet.ts
+++ b/src/diet.ts
@@ -383,7 +383,7 @@ export function bestConsumable(
   organType: "booze" | "food" | "spleen",
   levelRestrict = true,
   restrictList?: Item | Item[],
-  maxSize?: number,
+  maxSize?: number
 ): { edible: Item; value: number } {
   const fullMenu = potionMenu(menu(), 0, 0);
   let organMenu = fullMenu.filter((menuItem) => itemType(menuItem.item) === organType);

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -1543,7 +1543,7 @@ const freeRunFightSources = [
         1209: 2, // enter the gallery at Upscale Midnight
         1214: 1, // get High-End ginger wine
       });
-      const best = bestConsumable("booze", $items`high-end ginger wine, astral pilsner`);
+      const best = bestConsumable("booze", true, $items`high-end ginger wine, astral pilsner`);
       const gingerWineValue =
         (0.5 * 30 * (baseMeat + 750) +
           getAverageAdventures($item`high-end ginger wine`) * get("valueOfAdventure")) /


### PR DESCRIPTION
Noticed garbo get gingerbread cigarettes over high end ginger wine. Apparently next best consumable was dreadsylvanian grimlet, despite not being of level to drink one of those. Hence, adding in option to restrict BestCOnsumable to items you can currently drink based on level requirement