### PR TITLE
Add check for hobo monkey along with robort

### DIFF
--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -351,7 +351,7 @@ export function usingPurse(): boolean {
     cachedUsingPurse =
       myInebriety() <= inebrietyLimit() &&
       (!have($item`latte lovers member's mug`) ||
-        !have($familiar`Robortender`) ||
+        (!have($familiar`Robortender`) && !have($familiar`Hobo Monkey`)) ||
         !canAdventure($location`The Black Forest`));
   }
   return cachedUsingPurse;


### PR DESCRIPTION
With hobo monkey, and at current smithsness prices, latte beats Half a purse at embezzlers (and barf) even up to weight 215 hobo monkey

(Smithsness cost is ~48 mpa, so on embezzlers with boombox we gain 157mpa with the 20% meat over latte, so we need 15.3% meat from the 5 familiar weight to beat it, which is the case all the way up to a 215lb hobo monkey)

Ideally we could calculate the value of Half A Purse vs the cost of smithsness, but this is just a quick fix based on current prices similar to what we do with Cheengs.

There is also currently a bug with maximizer (see discord in garbo channel) where it will not currently value the half a purse more than latte anyway, so it uses smithsness but does not equip the purse