### PR TITLE
Equip terrible mutant gear if drops are needed

### DIFF
--- a/src/barfTurn.ts
+++ b/src/barfTurn.ts
@@ -233,8 +233,8 @@ const turns: AdventureAction[] = [
         new Requirement([], {
           forceEquip: [
             $item`"I Voted!" sticker`,
-            ...(!sober() && !isGhost ? $items`Drunkula's wineglass` : [])
-            ...(isMutant && !have($item`mutant crown`) ? $items`mutant arm, mutant leg`.filter((i) => have(i)) : [])
+            ...(!sober() && !isGhost ? $items`Drunkula's wineglass` : []),
+            ...(isMutant && !have($item`mutant crown`) ? $items`mutant arm, mutant leg`.filter((i) => have(i)) : []),
           ],
         })
       );

--- a/src/barfTurn.ts
+++ b/src/barfTurn.ts
@@ -234,7 +234,7 @@ const turns: AdventureAction[] = [
           forceEquip: [
             $item`"I Voted!" sticker`,
             ...(!sober() && !isGhost ? $items`Drunkula's wineglass` : []),
-            ...(isMutant && !have($item`mutant crown`) ? $items`mutant arms, mutant legs`.filter((i) => have(i)) : []),
+            ...(isMutant && !have($item`mutant crown`) ? $items`mutant arm, mutant legs`.filter((i) => have(i)) : []),
           ],
         })
       );

--- a/src/barfTurn.ts
+++ b/src/barfTurn.ts
@@ -227,14 +227,14 @@ const turns: AdventureAction[] = [
       get("_voteFreeFights") < 3,
     execute: () => {
       const isGhost = get("_voteMonster") === $monster`angry ghost`;
-      const isMutant = get("_voteMonster") === $monster`terrible mutant`;     
+      const isMutant = get("_voteMonster") === $monster`terrible mutant`;
 
       freeFightPrep(
         new Requirement([], {
           forceEquip: [
             $item`"I Voted!" sticker`,
             ...(!sober() && !isGhost ? $items`Drunkula's wineglass` : []),
-            ...(isMutant && !have($item`mutant crown`) ? $items`mutant arm, mutant leg`.filter((i) => have(i)) : []),
+            ...(isMutant && !have($item`mutant crown`) ? $items`mutant arms, mutant legs`.filter((i) => have(i)) : []),
           ],
         })
       );

--- a/src/barfTurn.ts
+++ b/src/barfTurn.ts
@@ -227,12 +227,14 @@ const turns: AdventureAction[] = [
       get("_voteFreeFights") < 3,
     execute: () => {
       const isGhost = get("_voteMonster") === $monster`angry ghost`;
+      const isMutant = get("_voteMonster") === $monster`terrible mutant`;     
 
       freeFightPrep(
         new Requirement([], {
           forceEquip: [
             $item`"I Voted!" sticker`,
-            ...(!sober() && !isGhost ? $items`Drunkula's wineglass` : []),
+            ...(!sober() && !isGhost ? $items`Drunkula's wineglass` : [])
+            ...(isMutant && !have($item`mutant crown`) ? $items`mutant arm, mutant leg`.filter((i) => have(i)) : [])
           ],
         })
       );


### PR DESCRIPTION
Equips a mutant leg and arm (if owned) when fighting a terrible mutant in order to get allow the next piece of mutant gear to drop, if the player doesn't already own it.