### PR TITLE
Add pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,6 @@ repos:
     rev: v4.3.0
     hooks:
       - id: check-yaml
-      - id: trailing-whitespace
       - id: check-merge-conflict
   - repo: https://gitlab.com/bmares/check-json5
     rev: v1.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: check-yaml
+      - id: trailing-whitespace
+      - id: check-merge-conflict
+  - repo: https://gitlab.com/bmares/check-json5
+    rev: v1.0.0
+    hooks:
+      - id: check-json5
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: "v8.24.0"
+    hooks:
+      - id: eslint
+        additional_dependencies:
+          - eslint@7.32.0
+          - eslint-config-prettier@8.3.0
+          - eslint-plugin-libram@0.2.17
+        files: \.[jt]sx?$ # *.js, *.jsx, *.ts and *.tsx
+        types: [file]
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: "v3.0.0-alpha.0"
+    hooks:
+      - id: prettier
+        additional_dependencies:
+          - prettier@2.5.1


### PR DESCRIPTION
Support optional pre-commit hooks, please see https://pre-commit.com/#install

Can be installed to ensure linters pass before committing files

```
% pre-commit install
pre-commit installed at .git/hooks/pre-commit
% pre-commit run                 
check yaml...............................................................Passed
check for merge conflicts................................................Passed
check json5..........................................(no files to check)Skipped
eslint...............................................(no files to check)Skipped
prettier.................................................................Passed
% pre-commit run --all-files
check yaml...............................................................Passed
check for merge conflicts................................................Passed
check json5..............................................................Passed
eslint...................................................................Passed
prettier.................................................................Passed
```