### PR TITLE
Remind users that nobarf may close NEP

### DIFF
--- a/mafia/data/garbo_help.json
+++ b/mafia/data/garbo_help.json
@@ -3,7 +3,7 @@
 
   {
     "tableItem": "nobarf",
-    "description": "garbo will do beginning of the day setup, embezzlers, and various daily flags, but will terminate before normal Barf Mountain turns."
+    "description": "garbo will do beginning of the day setup, embezzlers, and various daily flags, but will terminate before normal Barf Mountain turns. May close NEP for the day."
   },
   {
     "tableItem": "ascend",


### PR DESCRIPTION
NEP is a popular farming and leveling zone, there's a pretty good chance someone might run nobarf then expect to adventure in NEP. This will give us something to point at and say "hey you should read the manual, don't complain".