### PR TITLE
Preserve NEP during nobarf

### DIFF
--- a/src/dailies.ts
+++ b/src/dailies.ts
@@ -515,7 +515,10 @@ function nepQuest(): void {
 
   if (get("_questPartyFair") === "unstarted") {
     visitUrl(toUrl($location`The Neverending Party`));
-    if (["food", "booze", "trash", "dj"].includes(get("_questPartyFairQuest"))) {
+    if (
+      ["food", "booze"].includes(get("_questPartyFairQuest")) ||
+      (["trash", "dj"].includes(get("_questPartyFairQuest")) && !globalOptions.noBarf) // Preserve NEP if running nobarf
+    ) {
       runChoice(1); // Accept quest
     } else {
       runChoice(2); // Decline quest


### PR DESCRIPTION
NEP is a popular farming and leveling zone, there's a pretty good chance someone might run nobarf then expect to adventure in NEP. This will prevent nobarf from closing NEP during nobarf.