### PR TITLE
keepzonesopen arg

### DIFF
--- a/mafia/data/garbo_help.json
+++ b/mafia/data/garbo_help.json
@@ -30,6 +30,10 @@
     "description": "*EXPERIMENTAL* garbo will sacrifice some optimal behaviors to run quicker. Estimated and actual profits may be less accurate in this mode."
   },
   {
+    "tableItem": "keepzonesopen",
+    "description": "garbo will try to leave zones open that it could potentially close under normal circumstances - currently only applies to NEP."
+  },
+  {
     "tableItem": "Note on Arguments:",
     "description": "You can use multiple arguments in conjunction, e.g. \"garbo nobarf ascend\"."
   },

--- a/src/dailies.ts
+++ b/src/dailies.ts
@@ -515,7 +515,10 @@ function nepQuest(): void {
 
   if (get("_questPartyFair") === "unstarted") {
     visitUrl(toUrl($location`The Neverending Party`));
-    if (["food", "booze", "trash", "dj"].includes(get("_questPartyFairQuest"))) {
+    if (
+      ["food", "booze"].includes(get("_questPartyFairQuest")) ||
+      (["trash", "dj"].includes(get("_questPartyFairQuest")) && !globalOptions.noBarf) // Preserve NEP if running nobarf
+    ) {
       runChoice(1); // Accept quest
     } else {
       runChoice(2); // Decline quest

--- a/src/dailies.ts
+++ b/src/dailies.ts
@@ -517,7 +517,7 @@ function nepQuest(): void {
     visitUrl(toUrl($location`The Neverending Party`));
     if (
       ["food", "booze"].includes(get("_questPartyFairQuest")) ||
-      (["trash", "dj"].includes(get("_questPartyFairQuest")) && !globalOptions.keepZonesOpen) // Preserve NEP if running nobarf
+      (["trash", "dj"].includes(get("_questPartyFairQuest")) && !globalOptions.keepZonesOpen) // Preserve NEP if running keepzonesopen
     ) {
       runChoice(1); // Accept quest
     } else {

--- a/src/dailies.ts
+++ b/src/dailies.ts
@@ -517,7 +517,7 @@ function nepQuest(): void {
     visitUrl(toUrl($location`The Neverending Party`));
     if (
       ["food", "booze"].includes(get("_questPartyFairQuest")) ||
-      (["trash", "dj"].includes(get("_questPartyFairQuest")) && !globalOptions.noBarf) // Preserve NEP if running nobarf
+      (["trash", "dj"].includes(get("_questPartyFairQuest")) && !globalOptions.keepZonesOpen) // Preserve NEP if running nobarf
     ) {
       runChoice(1); // Accept quest
     } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,6 +168,8 @@ export function main(argString = ""): void {
       globalOptions.yachtzeeChain = true;
     } else if (arg.match(/quick/)) {
       globalOptions.quickMode = true;
+    } else if (arg.match(/keepzonesopen/i)) {
+      globalOptions.keepZonesOpen = true;
     } else if (arg.match(/version/i)) {
       return;
     } else if (arg) {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -95,6 +95,7 @@ export const globalOptions: {
   clarasBellClaimed: boolean;
   yachtzeeChain: boolean;
   quickMode: boolean;
+  keepZonesOpen: boolean;
 } = {
   stopTurncount: null,
   ascending: false,
@@ -108,6 +109,7 @@ export const globalOptions: {
   clarasBellClaimed: get("_claraBellUsed"),
   yachtzeeChain: false,
   quickMode: false,
+  keepZonesOpen: false,
 };
 
 export type BonusEquipMode = "free" | "embezzler" | "dmt" | "barf";


### PR DESCRIPTION
Adds the possibility of supplying an argument `keepzonesopen` to prevent garbo from taking actions that would close zones for the day. Currently only applies to NEP, but could be expanded to cover PR or FR if that content is ever utilized to an extent where the zones could be rendered inaccessible by garbo. An example of usage would be someone who wanted to run nobarf then farm little red dresses in NEP.