### PR TITLE
Use buff extenders even without embezzlers

### DIFF
--- a/src/fights.ts
+++ b/src/fights.ts
@@ -206,10 +206,6 @@ function embezzlerSetup() {
   safeRestore();
   freeFightMood().execute(50);
   useBuffExtenders();
-  if (have($item`License to Chill`) && !get("_licenseToChillUsed")) {
-    burnLibrams();
-    use($item`License to Chill`);
-  }
   burnLibrams(400);
   if (
     globalOptions.ascending &&

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -206,7 +206,7 @@ function embezzlerSetup() {
   meatMood(true, 750 + baseMeat).execute(embezzlerCount());
   safeRestore();
   freeFightMood().execute(50);
-  useBuffExtenders;
+  useBuffExtenders();
   if (have($item`License to Chill`) && !get("_licenseToChillUsed")) {
     burnLibrams();
     use($item`License to Chill`);

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -136,6 +136,7 @@ import {
   romanticMonsterImpossible,
   safeRestore,
   setChoice,
+  useBuffExtenders,
   userConfirmDialog,
 } from "./lib";
 import { freeFightMood, meatMood } from "./mood";
@@ -205,15 +206,7 @@ function embezzlerSetup() {
   meatMood(true, 750 + baseMeat).execute(embezzlerCount());
   safeRestore();
   freeFightMood().execute(50);
-  withStash($items`Platinum Yendorian Express Card, Bag o' Tricks`, () => {
-    if (have($item`Platinum Yendorian Express Card`) && !get("expressCardUsed")) {
-      burnLibrams();
-      use($item`Platinum Yendorian Express Card`);
-    }
-    if (have($item`Bag o' Tricks`) && !get("_bagOTricksUsed")) {
-      use($item`Bag o' Tricks`);
-    }
-  });
+  useBuffExtenders;
   if (have($item`License to Chill`) && !get("_licenseToChillUsed")) {
     burnLibrams();
     use($item`License to Chill`);

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -136,10 +136,9 @@ import {
   romanticMonsterImpossible,
   safeRestore,
   setChoice,
-  useBuffExtenders,
   userConfirmDialog,
 } from "./lib";
-import { freeFightMood, meatMood } from "./mood";
+import { freeFightMood, meatMood, useBuffExtenders } from "./mood";
 import { freeFightOutfit, meatOutfit, tryFillLatte, waterBreathingEquipment } from "./outfit";
 import { bathroomFinance, potionSetup } from "./potions";
 import {

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,7 @@ import {
   propertyManager,
   questStep,
   safeRestore,
+  useBuffExtenders,
   userConfirmDialog,
 } from "./lib";
 import { meatMood } from "./mood";
@@ -446,6 +447,7 @@ export function main(argString = ""): void {
           potionSetup(false);
           maximize("MP", false);
           meatMood().execute(estimatedTurns());
+          useBuffExtenders();
           try {
             while (canContinue()) {
               barfTurn();

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,10 +56,9 @@ import {
   propertyManager,
   questStep,
   safeRestore,
-  useBuffExtenders,
   userConfirmDialog,
 } from "./lib";
-import { meatMood } from "./mood";
+import { meatMood, useBuffExtenders } from "./mood";
 import postCombatActions from "./post";
 import { stashItems, withStash, withVIPClan } from "./clan";
 import { dailySetup, postFreeFightDailySetup } from "./dailies";

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -48,6 +48,7 @@ import {
   $effect,
   $familiar,
   $item,
+  $items,
   $location,
   $monster,
   $skill,
@@ -72,6 +73,7 @@ import {
   uneffect,
 } from "libram";
 import { garboValue } from "./session";
+import { withStash } from "./clan";
 
 export const embezzlerLog: {
   initialEmbezzlersFought: number;
@@ -352,6 +354,21 @@ export function burnLibrams(mpTarget = 0): void {
   } else {
     cliExecute("burn *");
   }
+}
+
+/**
+ * Use buff extenders like PYEC and Bag o Tricks
+ */
+export function useBuffExtenders(): void {
+  withStash($items`Platinum Yendorian Express Card, Bag o' Tricks`, () => {
+    if (have($item`Platinum Yendorian Express Card`) && !get("expressCardUsed")) {
+      burnLibrams();
+      use($item`Platinum Yendorian Express Card`);
+    }
+    if (have($item`Bag o' Tricks`) && !get("_bagOTricksUsed")) {
+      use($item`Bag o' Tricks`);
+    }
+  });
 }
 
 export function safeRestoreMpTarget(): number {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -48,7 +48,6 @@ import {
   $effect,
   $familiar,
   $item,
-  $items,
   $location,
   $monster,
   $skill,
@@ -73,7 +72,6 @@ import {
   uneffect,
 } from "libram";
 import { garboValue } from "./session";
-import { withStash } from "./clan";
 
 export const embezzlerLog: {
   initialEmbezzlersFought: number;
@@ -354,21 +352,6 @@ export function burnLibrams(mpTarget = 0): void {
   } else {
     cliExecute("burn *");
   }
-}
-
-/**
- * Use buff extenders like PYEC and Bag o Tricks
- */
-export function useBuffExtenders(): void {
-  withStash($items`Platinum Yendorian Express Card, Bag o' Tricks`, () => {
-    if (have($item`Platinum Yendorian Express Card`) && !get("expressCardUsed")) {
-      burnLibrams();
-      use($item`Platinum Yendorian Express Card`);
-    }
-    if (have($item`Bag o' Tricks`) && !get("_bagOTricksUsed")) {
-      use($item`Bag o' Tricks`);
-    }
-  });
 }
 
 export function safeRestoreMpTarget(): number {

--- a/src/mood.ts
+++ b/src/mood.ts
@@ -216,6 +216,10 @@ export function useBuffExtenders(): void {
       use($item`Bag o' Tricks`);
     }
   });
+  if (have($item`License to Chill`) && !get("_licenseToChillUsed")) {
+    burnLibrams();
+    use($item`License to Chill`);
+  }
 }
 
 const stings = [

--- a/src/mood.ts
+++ b/src/mood.ts
@@ -27,7 +27,7 @@ import {
   uneffect,
   Witchess,
 } from "libram";
-import { baseMeat, questStep, safeRestoreMpTarget, setChoice } from "./lib";
+import { baseMeat, burnLibrams, questStep, safeRestoreMpTarget, setChoice } from "./lib";
 import { withStash } from "./clan";
 import { usingPurse } from "./outfit";
 
@@ -201,6 +201,21 @@ export function freeFightMood(...additionalEffects: Effect[]): Mood {
   if (getWorkshed() === $item`Asdon Martin keyfob`) mood.drive(AsdonMartin.Driving.Observantly);
 
   return mood;
+}
+
+/**
+ * Use buff extenders like PYEC and Bag o Tricks
+ */
+export function useBuffExtenders(): void {
+  withStash($items`Platinum Yendorian Express Card, Bag o' Tricks`, () => {
+    if (have($item`Platinum Yendorian Express Card`) && !get("expressCardUsed")) {
+      burnLibrams();
+      use($item`Platinum Yendorian Express Card`);
+    }
+    if (have($item`Bag o' Tricks`) && !get("_bagOTricksUsed")) {
+      use($item`Bag o' Tricks`);
+    }
+  });
 }
 
 const stings = [


### PR DESCRIPTION
So the implementation is pretty simple (just use the buff extenders before we start running barf if we didn't use them during embezzlers)

But I'm unsure of where the function should live (if it even should?) my guess was we didn't just want just the raw code in index.ts

My suspicion is that the way I set it up (function living in lib.ts) is probably incorrect because it requires an import from clan.ts.

Perhaps it should be put in mood.ts instead?