### PR TITLE
Use writeCcs instead of garbo-combat.js.

### DIFF
--- a/src/barfTurn.ts
+++ b/src/barfTurn.ts
@@ -28,8 +28,6 @@ import {
   $location,
   $monster,
   $skill,
-  adventureMacro,
-  adventureMacroAuto,
   clamp,
   Counter,
   ensureEffect,
@@ -39,7 +37,7 @@ import {
   Requirement,
   SourceTerminal,
 } from "libram";
-import { Macro, withMacro } from "./combat";
+import { adventureMacro, adventureMacroAuto, Macro, withMacro } from "./combat";
 import { computeDiet, consumeDiet } from "./diet";
 import { barfFamiliar, freeFightFamiliar, meatFamiliar } from "./familiar";
 import { deliverThesisIfAble } from "./fights";

--- a/src/barfTurn.ts
+++ b/src/barfTurn.ts
@@ -37,7 +37,7 @@ import {
   Requirement,
   SourceTerminal,
 } from "libram";
-import { adventureMacro, adventureMacroAuto, Macro, withMacro } from "./combat";
+import { garboAdventure, garboAdventureAuto, Macro, withMacro } from "./combat";
 import { computeDiet, consumeDiet } from "./diet";
 import { barfFamiliar, freeFightFamiliar, meatFamiliar } from "./familiar";
 import { deliverThesisIfAble } from "./fights";
@@ -199,7 +199,7 @@ const turns: AdventureAction[] = [
           }
         )
       );
-      adventureMacro(ghostLocation, Macro.ghostBustin());
+      garboAdventure(ghostLocation, Macro.ghostBustin());
       return get("questPAGhost") === "unstarted";
     },
     spendsTurn: false,
@@ -228,7 +228,7 @@ const turns: AdventureAction[] = [
           ],
         })
       );
-      adventureMacroAuto(
+      garboAdventureAuto(
         isGhost ? drunkSafeWander("wanderer") : wanderWhere("wanderer"),
         Macro.basicCombat()
       );
@@ -252,7 +252,7 @@ const turns: AdventureAction[] = [
       if (underwater) retrieveItem($item`pulled green taffy`);
 
       isEmbezzler ? embezzlerPrep({ sea: underwater }) : freeFightPrep();
-      adventureMacroAuto(
+      garboAdventureAuto(
         targetLocation,
         Macro.externalIf(underwater, Macro.item($item`pulled green taffy`)).meatKill(),
 
@@ -273,7 +273,7 @@ const turns: AdventureAction[] = [
     available: () => kramcoGuaranteed() && romanticMonsterImpossible(),
     execute: () => {
       freeFightPrep(new Requirement([], { forceEquip: $items`Kramco Sausage-o-Matic™` }));
-      adventureMacroAuto(drunkSafeWander("wanderer"), Macro.basicCombat());
+      garboAdventureAuto(drunkSafeWander("wanderer"), Macro.basicCombat());
       return !kramcoGuaranteed();
     },
     spendsTurn: false,
@@ -287,7 +287,7 @@ const turns: AdventureAction[] = [
       get("_voidFreeFights") < 5,
     execute: () => {
       freeFightPrep(new Requirement([], { forceEquip: $items`cursed magnifying glass` }));
-      adventureMacroAuto(drunkSafeWander("wanderer"), Macro.basicCombat());
+      garboAdventureAuto(drunkSafeWander("wanderer"), Macro.basicCombat());
       return get("cursedMagnifyingGlassCount") === 0;
     },
     spendsTurn: false,
@@ -324,7 +324,7 @@ const turns: AdventureAction[] = [
         .familiarActions()
         .trySkill($skill`Duplicate`)
         .skill($skill`Spit jurassic acid`);
-      adventureMacroAuto(location, macro);
+      garboAdventureAuto(location, macro);
       if (SourceTerminal.have()) {
         SourceTerminal.educate([$skill`Extract`, $skill`Digitize`]);
       }
@@ -364,7 +364,7 @@ const turns: AdventureAction[] = [
         false,
         lubing ? new Requirement([], { forceEquip: $items`lube-shoes` }) : undefined
       );
-      adventureMacroAuto(
+      garboAdventureAuto(
         $location`Barf Mountain`,
         Macro.meatKill(),
         Macro.if_(

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -681,7 +681,7 @@ export function withMacro<T, M extends StrictMacro>(macro: M, action: () => T, t
  * @param loc Location to adventure in.
  * @param macro Macro to execute.
  */
-export function adventureMacro<M extends StrictMacro>(loc: Location, macro: M): void {
+export function garboAdventure<M extends StrictMacro>(loc: Location, macro: M): void {
   if (getAutoAttack() !== 0) setAutoAttack(0);
   makeCcs(macro);
   completeCombat(() => adv1(loc, -1, ""));
@@ -697,7 +697,7 @@ export function adventureMacro<M extends StrictMacro>(loc: Location, macro: M): 
  * @param autoMacro Macro to execute via KoL autoattack.
  * @param nextMacro Macro to execute manually after autoattack completes.
  */
-export function adventureMacroAuto<M extends StrictMacro>(
+export function garboAdventureAuto<M extends StrictMacro>(
   loc: Location,
   autoMacro: M,
   nextMacro = Macro.abort()

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -28,7 +28,6 @@ import {
   mySoulsauce,
   myThrall,
   numericModifier,
-  print,
   retrieveItem,
   runCombat,
   setAutoAttack,
@@ -156,11 +155,6 @@ export function shouldRedigitize(): boolean {
 }
 
 export class Macro extends StrictMacro {
-  submit(): string {
-    print(this.components.join(";"));
-    return super.submit();
-  }
-
   tryHaveSkill(skill: Skill | null): Macro {
     if (!skill) return this;
     return this.externalIf(haveSkill(skill), Macro.trySkill(skill));
@@ -639,7 +633,6 @@ function customizeMacro<M extends StrictMacro>(macro: M) {
 }
 
 function makeCcs<M extends StrictMacro>(macro: M) {
-  print(customizeMacro(macro).toString());
   writeCcs(`[default]\n"${customizeMacro(macro).toString()}"`, "garbo");
   propertyManager.set({ customCombatScript: "garbo" });
 }
@@ -659,7 +652,7 @@ function runCombatBy<T>(initiateCombatAction: () => T) {
  * Attempt to perform a nonstandard combat-starting Action with a Macro
  * @param macro The Macro to attempt to use
  * @param action The combat-starting action to attempt
- * @param tryAuto Whether or not we should try to resolve the combat with an autoattack; autoattack macros can fail against special monsters, and thus we have to submit a macro with Macro.save() regardless
+ * @param tryAuto Whether or not we should try to resolve the combat with an autoattack; autoattack macros can fail against special monsters, and thus we have to submit a macro via CCS regardless.
  * @returns The output of your specified action function (typically void)
  */
 export function withMacro<T, M extends StrictMacro>(macro: M, action: () => T, tryAuto = false): T {
@@ -667,7 +660,7 @@ export function withMacro<T, M extends StrictMacro>(macro: M, action: () => T, t
   if (tryAuto) macro.setAutoAttack();
   makeCcs(macro);
   try {
-    return action();
+    return runCombatBy(action);
   } finally {
     if (tryAuto) setAutoAttack(0);
   }

--- a/src/embezzler.ts
+++ b/src/embezzler.ts
@@ -45,7 +45,7 @@ import {
   sum,
 } from "libram";
 import { acquire } from "./acquire";
-import { adventureMacro, adventureMacroAuto, Macro, shouldRedigitize, withMacro } from "./combat";
+import { garboAdventure, garboAdventureAuto, Macro, shouldRedigitize, withMacro } from "./combat";
 import { crateStrategy, doingExtrovermectin, equipOrbIfDesired } from "./extrovermectin";
 import {
   averageEmbezzlerNet,
@@ -334,7 +334,7 @@ export const chainStarters = [
         set("_freePillKeeperUsed", true);
         return;
       }
-      const adventureFunction = options.useAuto ? adventureMacroAuto : adventureMacro;
+      const adventureFunction = options.useAuto ? garboAdventureAuto : garboAdventure;
       adventureFunction($location`Cobb's Knob Treasury`, options.macro, options.macro);
     }
   ),
@@ -492,7 +492,7 @@ export const wanderSources = [
     () => canAdventure($location`Cobb's Knob Treasury`) && have($effect`Lucky!`),
     () => (canAdventure($location`Cobb's Knob Treasury`) && have($effect`Lucky!`) ? 1 : 0),
     (options: EmbezzlerFightRunOptions) => {
-      const adventureFunction = options.useAuto ? adventureMacroAuto : adventureMacro;
+      const adventureFunction = options.useAuto ? garboAdventureAuto : garboAdventure;
       adventureFunction($location`Cobb's Knob Treasury`, options.macro, options.macro);
     }
   ),
@@ -502,7 +502,7 @@ export const wanderSources = [
       get("_sourceTerminalDigitizeMonster") === embezzler && Counter.get("Digitize Monster") <= 0,
     () => (SourceTerminal.have() && SourceTerminal.getDigitizeUses() === 0 ? 1 : 0),
     (options: EmbezzlerFightRunOptions) => {
-      const adventureFunction = options.useAuto ? adventureMacroAuto : adventureMacro;
+      const adventureFunction = options.useAuto ? garboAdventureAuto : garboAdventure;
       adventureFunction(
         options.location,
         wandererFailsafeMacro().step(options.macro),
@@ -521,7 +521,7 @@ export const wanderSources = [
       Counter.get("Romantic Monster window end") <= 0,
     () => 0,
     (options: EmbezzlerFightRunOptions) => {
-      const adventureFunction = options.useAuto ? adventureMacroAuto : adventureMacro;
+      const adventureFunction = options.useAuto ? garboAdventureAuto : garboAdventure;
       adventureFunction(
         options.location,
         wandererFailsafeMacro().step(options.macro),
@@ -541,7 +541,7 @@ export const wanderSources = [
         ? 1
         : 0,
     (options: EmbezzlerFightRunOptions) => {
-      const adventureFunction = options.useAuto ? adventureMacroAuto : adventureMacro;
+      const adventureFunction = options.useAuto ? garboAdventureAuto : garboAdventure;
       adventureFunction(
         options.location,
         wandererFailsafeMacro().step(options.macro),
@@ -575,7 +575,7 @@ export const conditionalSources = [
       ) {
         return;
       }
-      const adventureFunction = options.useAuto ? adventureMacroAuto : adventureMacro;
+      const adventureFunction = options.useAuto ? garboAdventureAuto : garboAdventure;
       adventureFunction($location`The Dire Warren`, options.macro, options.macro);
       toasterGaze();
       if (!doingExtrovermectin()) set("_garbo_doneGregging", true);
@@ -621,7 +621,7 @@ export const conditionalSources = [
           )
           .skill($skill`Macrometeorite`)
       ).step(options.macro);
-      const adventureFunction = options.useAuto ? adventureMacroAuto : adventureMacro;
+      const adventureFunction = options.useAuto ? garboAdventureAuto : garboAdventure;
       adventureFunction($location`Noob Cave`, macro, macro);
       if (CrystalBall.ponder().get($location`Noob Cave`) === embezzler) toasterGaze();
     },
@@ -665,7 +665,7 @@ export const conditionalSources = [
           )
           .skill($skill`CHEAT CODE: Replace Enemy`)
       ).step(options.macro);
-      const adventureFunction = options.useAuto ? adventureMacroAuto : adventureMacro;
+      const adventureFunction = options.useAuto ? garboAdventureAuto : garboAdventure;
       adventureFunction($location`Noob Cave`, macro, macro);
       if (CrystalBall.ponder().get($location`Noob Cave`) === embezzler) toasterGaze();
     },
@@ -686,7 +686,7 @@ export const conditionalSources = [
     (options: EmbezzlerFightRunOptions) => {
       const run = ltbRun();
       run.constraints.preparation?.();
-      const adventureFunction = options.useAuto ? adventureMacroAuto : adventureMacro;
+      const adventureFunction = options.useAuto ? garboAdventureAuto : garboAdventure;
       adventureFunction(
         $location`The Dire Warren`,
         Macro.if_($monster`fluffy bunny`, run.macro).step(options.macro),
@@ -715,7 +715,7 @@ export const conditionalSources = [
         ? 1
         : 0,
     (options: EmbezzlerFightRunOptions) => {
-      adventureMacro($location`The Dire Warren`, Macro.if_(embezzler, options.macro).abort());
+      garboAdventure($location`The Dire Warren`, Macro.if_(embezzler, options.macro).abort());
     },
     {
       requirements: [
@@ -734,7 +734,7 @@ export const conditionalSources = [
       get("_backUpUses") < 11,
     () => (have($item`backup camera`) ? 11 - get("_backUpUses") : 0),
     (options: EmbezzlerFightRunOptions) => {
-      const adventureFunction = options.useAuto ? adventureMacroAuto : adventureMacro;
+      const adventureFunction = options.useAuto ? garboAdventureAuto : garboAdventure;
       adventureFunction(
         options.location,
         Macro.if_(
@@ -823,7 +823,7 @@ export const emergencyChainStarters = [
       );
       use($item`11-leaf clover`);
       if (have($effect`Lucky!`)) {
-        const adventureFunction = options.useAuto ? adventureMacroAuto : adventureMacro;
+        const adventureFunction = options.useAuto ? garboAdventureAuto : garboAdventure;
         adventureFunction($location`Cobb's Knob Treasury`, options.macro, options.macro);
       }
       globalOptions.askedAboutWish = false;

--- a/src/embezzler.ts
+++ b/src/embezzler.ts
@@ -31,8 +31,6 @@ import {
   $monster,
   $monsters,
   $skill,
-  adventureMacro,
-  adventureMacroAuto,
   ChateauMantegna,
   CombatLoversLocket,
   Counter,
@@ -47,7 +45,7 @@ import {
   sum,
 } from "libram";
 import { acquire } from "./acquire";
-import { Macro, shouldRedigitize, withMacro } from "./combat";
+import { adventureMacro, adventureMacroAuto, Macro, shouldRedigitize, withMacro } from "./combat";
 import { crateStrategy, doingExtrovermectin, equipOrbIfDesired } from "./extrovermectin";
 import {
   averageEmbezzlerNet,

--- a/src/extrovermectin.ts
+++ b/src/extrovermectin.ts
@@ -20,7 +20,6 @@ import {
   $monsters,
   $skill,
   $slot,
-  adventureMacro,
   clamp,
   CrystalBall,
   get,
@@ -32,7 +31,7 @@ import {
 } from "libram";
 import { freeFightFamiliar } from "./familiar";
 import { globalOptions, latteActionSourceFinderConstraints, ltbRun, maxBy, setChoice } from "./lib";
-import { Macro } from "./combat";
+import { garboAdventure, Macro } from "./combat";
 import { embezzlerMacro } from "./embezzler";
 import { acquire } from "./acquire";
 
@@ -120,7 +119,7 @@ export function saberCrateIfSafe(): void {
       .merge(run.constraints.equipmentRequirements?.() ?? new Requirement([], {}))
       .maximize();
     setChoice(1387, 2);
-    adventureMacro(
+    garboAdventure(
       $location`Noob Cave`,
       Macro.if_($monster`crate`, Macro.skill($skill`Use the Force`))
         .if_($monsters`giant rubber spider, time-spinner prank`, Macro.kill())
@@ -199,7 +198,7 @@ function initializeCrates(): void {
       })
         .merge(run.constraints.equipmentRequirements?.() ?? new Requirement([], {}))
         .maximize();
-      adventureMacro(
+      garboAdventure(
         $location`Noob Cave`,
         Macro.if_($monster`crate`, macro)
           .if_($monsters`giant rubber spider, time-spinner prank`, Macro.kill())
@@ -252,7 +251,7 @@ function initializeDireWarren(): void {
     }).maximize();
 
     do {
-      adventureMacro(
+      garboAdventure(
         $location`The Dire Warren`,
         Macro.if_($monster`fluffy bunny`, Macro.skill($skill`Batter Up!`)).step(embezzlerMacro())
       );
@@ -264,7 +263,7 @@ function initializeDireWarren(): void {
     const banish = maxBy(options, mallPrice, true);
     acquire(1, banish, 50000, true);
     do {
-      adventureMacro(
+      garboAdventure(
         $location`The Dire Warren`,
         Macro.if_($monster`fluffy bunny`, Macro.item(banish)).step(embezzlerMacro())
       );

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -1258,7 +1258,7 @@ const freeFightSources = [
         ? clamp(10 - get("_neverendingPartyFreeTurns") - (get("_thesisDelivered") ? 0 : 1), 0, 10)
         : 0,
     () => {
-      const constructedMacro = Macro.tryHaveSkill($skill`Feel Pride`).step(Macro.load());
+      const constructedMacro = Macro.tryHaveSkill($skill`Feel Pride`).basicCombat();
       setNepQuestChoicesAndPrepItems();
       garboAdventure($location`The Neverending Party`, constructedMacro);
     },

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -104,7 +104,7 @@ import {
 } from "libram";
 import { acquire } from "./acquire";
 import { withStash } from "./clan";
-import { adventureMacro, adventureMacroAuto, Macro, withMacro } from "./combat";
+import { garboAdventure, garboAdventureAuto, Macro, withMacro } from "./combat";
 import {
   bestFairy,
   freeFightFamiliar,
@@ -220,7 +220,7 @@ function embezzlerSetup() {
       useFamiliar(run.constraints.familiar?.() ?? freeFightFamiliar());
       run.constraints.preparation?.();
       freeFightOutfit(run.constraints.equipmentRequirements?.());
-      adventureMacro($location`The Hidden Temple`, run.macro);
+      garboAdventure($location`The Hidden Temple`, run.macro);
     }
   }
 
@@ -314,7 +314,7 @@ function startWandererCounter() {
         run.constraints.preparation?.();
         freeFightOutfit(run.constraints.equipmentRequirements?.());
       }
-      adventureMacro(
+      garboAdventure(
         $location`The Haunted Kitchen`,
         Macro.if_($monster`Knob Goblin Embezzler`, embezzlerMacro()).step(run.macro)
       );
@@ -677,7 +677,7 @@ const freeFightSources = [
     () => {
       const ghostLocation = get("ghostLocation");
       if (!ghostLocation) return;
-      adventureMacro(ghostLocation, Macro.ghostBustin());
+      garboAdventure(ghostLocation, Macro.ghostBustin());
     },
     true,
     {
@@ -906,7 +906,7 @@ const freeFightSources = [
           retrieveItem(1, $item`Louder Than Bomb`);
           retrieveItem(1, $item`divine champagne popper`);
         }
-        adventureMacro(
+        garboAdventure(
           $location`Domed City of Grimacia`,
           Macro.if_(
             $monster`alielf`,
@@ -965,7 +965,7 @@ const freeFightSources = [
       retrieveItem($item`Louder Than Bomb`);
       retrieveItem($item`tennis ball`);
       retrieveItem($item`divine champagne popper`);
-      adventureMacro($location`The Hidden Bowling Alley`, pygmyMacro);
+      garboAdventure($location`The Hidden Bowling Alley`, pygmyMacro);
     },
     true,
     {
@@ -986,7 +986,7 @@ const freeFightSources = [
     () => {
       putCloset(itemAmount($item`bowling ball`), $item`bowling ball`);
       retrieveItem($item`Bowl of Scorpions`);
-      adventureMacro($location`The Hidden Bowling Alley`, pygmyMacro);
+      garboAdventure($location`The Hidden Bowling Alley`, pygmyMacro);
     },
     true,
     pygmyOptions($items`miniature crystal ball`.filter((item) => have(item)))
@@ -1000,7 +1000,7 @@ const freeFightSources = [
     () => {
       putCloset(itemAmount($item`bowling ball`), $item`bowling ball`);
       retrieveItem($item`Bowl of Scorpions`);
-      adventureMacroAuto($location`The Hidden Bowling Alley`, pygmyMacro);
+      garboAdventureAuto($location`The Hidden Bowling Alley`, pygmyMacro);
     },
     true,
     pygmyOptions()
@@ -1032,12 +1032,12 @@ const freeFightSources = [
       ) {
         putCloset(itemAmount($item`bowling ball`), $item`bowling ball`);
         putCloset(itemAmount($item`Bowl of Scorpions`), $item`Bowl of Scorpions`);
-        adventureMacro($location`The Hidden Bowling Alley`, Macro.skill($skill`Use the Force`));
+        garboAdventure($location`The Hidden Bowling Alley`, Macro.skill($skill`Use the Force`));
       } else {
         if (closetAmount($item`Bowl of Scorpions`) > 0) {
           takeCloset(closetAmount($item`Bowl of Scorpions`), $item`Bowl of Scorpions`);
         } else retrieveItem($item`Bowl of Scorpions`);
-        adventureMacro($location`The Hidden Bowling Alley`, pygmyMacro);
+        garboAdventure($location`The Hidden Bowling Alley`, pygmyMacro);
       }
     },
     false,
@@ -1053,7 +1053,7 @@ const freeFightSources = [
     () => {
       putCloset(itemAmount($item`bowling ball`), $item`bowling ball`);
       retrieveItem(1, $item`Bowl of Scorpions`);
-      adventureMacro(
+      garboAdventure(
         $location`The Hidden Bowling Alley`,
         Macro.if_($monster`drunk pygmy`, pygmyMacro).abort()
       );
@@ -1100,7 +1100,7 @@ const freeFightSources = [
         ? clamp(5 - get("_glarkCableUses"), 0, itemAmount($item`glark cable`))
         : 0,
     () => {
-      adventureMacro($location`The Red Zeppelin`, Macro.item($item`glark cable`));
+      garboAdventure($location`The Red Zeppelin`, Macro.item($item`glark cable`));
     },
     true,
     {
@@ -1119,7 +1119,7 @@ const freeFightSources = [
       if (SourceTerminal.have()) {
         SourceTerminal.educate([$skill`Extract`, $skill`Portscan`]);
       }
-      adventureMacro(
+      garboAdventure(
         $location`Your Mushroom Garden`,
         Macro.externalIf(
           !doingExtrovermectin(),
@@ -1148,7 +1148,7 @@ const freeFightSources = [
       if (SourceTerminal.have()) {
         SourceTerminal.educate([$skill`Extract`, $skill`Portscan`]);
       }
-      adventureMacro(
+      garboAdventure(
         $location`Your Mushroom Garden`,
         Macro.if_($monster`Government agent`, Macro.skill($skill`Macrometeorite`)).if_(
           $monster`piranha plant`,
@@ -1210,7 +1210,7 @@ const freeFightSources = [
       if (sensation) {
         acquire(1, $item`abstraction: sensation`, garboValue($item`abstraction: motion`), false);
       }
-      adventureMacro(
+      garboAdventure(
         $location`The Deep Machine Tunnels`,
         Macro.externalIf(
           thought,
@@ -1260,7 +1260,7 @@ const freeFightSources = [
     () => {
       const constructedMacro = Macro.tryHaveSkill($skill`Feel Pride`).step(Macro.load());
       setNepQuestChoicesAndPrepItems();
-      adventureMacro($location`The Neverending Party`, constructedMacro);
+      garboAdventure($location`The Neverending Party`, constructedMacro);
     },
     true,
     {
@@ -1303,7 +1303,7 @@ const freeFightSources = [
       canEquip($item`The Jokester's gun`) &&
       questStep("questL08Trapper") >= 2,
     () =>
-      adventureMacro(
+      garboAdventure(
         $location`Lair of the Ninja Snowmen`,
         Macro.skill($skill`Fire the Jokester's Gun`).abort()
       ),
@@ -1354,7 +1354,7 @@ const freeRunFightSources = [
         [923]: 1, // go to the blackberries in All Around the Map
         [924]: 1, // fight a blackberry bush, so that we can freerun
       });
-      adventureMacro($location`The Black Forest`, runSource.macro);
+      garboAdventure($location`The Black Forest`, runSource.macro);
     },
     {
       requirements: () => [new Requirement([], { forceEquip: $items`latte lovers member's mug` })],
@@ -1371,7 +1371,7 @@ const freeRunFightSources = [
         [502]: 2, // go towards the stream in Arboreal Respite, so we can skip adventure
         [505]: 2, // skip adventure
       });
-      adventureMacro($location`The Spooky Forest`, runSource.macro);
+      garboAdventure($location`The Spooky Forest`, runSource.macro);
     },
     {
       requirements: () => [new Requirement([], { forceEquip: $items`latte lovers member's mug` })],
@@ -1385,7 +1385,7 @@ const freeRunFightSources = [
       get("latteUnlocks").includes("cajun") &&
       get("latteUnlocks").includes("rawhide"),
     (runSource: ActionSource) => {
-      adventureMacro($location`The Dire Warren`, runSource.macro);
+      garboAdventure($location`The Dire Warren`, runSource.macro);
     },
     {
       requirements: () => [new Requirement([], { forceEquip: $items`latte lovers member's mug` })],
@@ -1398,7 +1398,7 @@ const freeRunFightSources = [
       get("_spaceJellyfishDrops") < 5 &&
       getStenchLocation() !== $location`none`,
     (runSource: ActionSource) => {
-      adventureMacro(
+      garboAdventure(
         getStenchLocation(),
         Macro.trySkill($skill`Extract Jelly`).step(runSource.macro)
       );
@@ -1415,7 +1415,7 @@ const freeRunFightSources = [
       get("_macrometeoriteUses") < 10 &&
       getStenchLocation() !== $location`none`,
     (runSource: ActionSource) => {
-      adventureMacro(
+      garboAdventure(
         getStenchLocation(),
         Macro.while_(
           "!pastround 28 && hasskill macrometeorite",
@@ -1437,7 +1437,7 @@ const freeRunFightSources = [
       get("_powerfulGloveBatteryPowerUsed") < 91 &&
       getStenchLocation() !== $location`none`,
     (runSource: ActionSource) => {
-      adventureMacro(
+      garboAdventure(
         getStenchLocation(),
         Macro.while_(
           "!pastround 28 && hasskill CHEAT CODE: Replace Enemy",
@@ -1462,7 +1462,7 @@ const freeRunFightSources = [
       propertyManager.setChoices({
         1215: 1, // Gingerbread Civic Center advance clock
       });
-      adventureMacro($location`Gingerbread Civic Center`, Macro.abort());
+      garboAdventure($location`Gingerbread Civic Center`, Macro.abort());
     },
     false,
     {
@@ -1477,7 +1477,7 @@ const freeRunFightSources = [
       propertyManager.setChoices({
         1215: 1, // Gingerbread Civic Center advance clock
       });
-      adventureMacro($location`Gingerbread Civic Center`, runSource.macro);
+      garboAdventure($location`Gingerbread Civic Center`, runSource.macro);
       if (
         [
           "Even Tamer Than Usual",
@@ -1505,7 +1505,7 @@ const freeRunFightSources = [
       propertyManager.setChoices({
         1204: 1, // Gingerbread Train Station Noon random candy
       });
-      adventureMacro($location`Gingerbread Train Station`, Macro.abort());
+      garboAdventure($location`Gingerbread Train Station`, Macro.abort());
     },
     false,
     {
@@ -1522,7 +1522,7 @@ const freeRunFightSources = [
       propertyManager.setChoices({
         1215: 1, // Gingerbread Civic Center advance clock
       });
-      adventureMacro($location`Gingerbread Civic Center`, runSource.macro);
+      garboAdventure($location`Gingerbread Civic Center`, runSource.macro);
       if (
         [
           "Even Tamer Than Usual",
@@ -1567,9 +1567,9 @@ const freeRunFightSources = [
             itemAmount($item`high-end ginger wine`) < 11))
       ) {
         outfit("gingerbread best");
-        adventureMacro($location`Gingerbread Upscale Retail District`, Macro.abort());
+        garboAdventure($location`Gingerbread Upscale Retail District`, Macro.abort());
       } else {
-        adventureMacro($location`Gingerbread Civic Center`, Macro.abort());
+        garboAdventure($location`Gingerbread Civic Center`, Macro.abort());
       }
     },
     false,
@@ -1665,7 +1665,7 @@ const freeRunFightSources = [
       (have($familiar`Mini-Hipster`) || have($familiar`Artistic Goth Kid`)),
     (runSource: ActionSource) => {
       const targetLocation = wanderWhere("backup");
-      adventureMacro(
+      garboAdventure(
         targetLocation,
         Macro.if_(
           `(monsterid 969) || (monsterid 970) || (monsterid 971) || (monsterid 972) || (monsterid 973) || (monstername Black Crayon *)`,
@@ -1698,7 +1698,7 @@ const freeRunFightSources = [
       canAdventure($location`Cobb's Knob Menagerie, Level 1`) &&
       get("_mayflySummons") < 30,
     (runSource: ActionSource) => {
-      adventureMacro(
+      garboAdventure(
         $location`Cobb's Knob Menagerie, Level 1`,
         Macro.if_($monster`QuickBASIC elemental`, Macro.basicCombat())
           .if_($monster`BASIC Elemental`, Macro.trySkill($skill`Summon Mayfly Swarm`))
@@ -2052,7 +2052,7 @@ export function deliverThesisIfAble(): void {
     thesisLocation = $location`Hamburglaris Shield Generator`;
   }
 
-  adventureMacro(
+  garboAdventure(
     thesisLocation,
     Macro.if_($monsters`giant rubber spider, time-spinner prank`, Macro.basicCombat()).skill(
       $skill`deliver your thesis!`
@@ -2068,7 +2068,7 @@ export function doSausage(): void {
   useFamiliar(freeFightFamiliar());
   freeFightOutfit(new Requirement([], { forceEquip: $items`Kramco Sausage-o-Matic™` }));
   do {
-    adventureMacroAuto(
+    garboAdventureAuto(
       wanderWhere("wanderer"),
       Macro.if_($monster`sausage goblin`, Macro.basicCombat())
         .ifHolidayWanderer(Macro.basicCombat())
@@ -2085,7 +2085,7 @@ function doGhost() {
   if (!ghostLocation) return;
   useFamiliar(freeFightFamiliar());
   freeFightOutfit(new Requirement([], { forceEquip: $items`protonic accelerator pack` }));
-  adventureMacro(ghostLocation, Macro.ghostBustin());
+  garboAdventure(ghostLocation, Macro.ghostBustin());
   postCombatActions();
 }
 
@@ -2252,7 +2252,7 @@ function voidMonster(): void {
 
   useFamiliar(freeFightFamiliar());
   freeFightOutfit(new Requirement([], { forceEquip: $items`cursed magnifying glass` }));
-  adventureMacro(wanderWhere("wanderer"), Macro.basicCombat());
+  garboAdventure(wanderWhere("wanderer"), Macro.basicCombat());
   postCombatActions();
 }
 
@@ -2321,7 +2321,7 @@ function killRobortCreaturesForFree() {
   ) {
     if (have($effect`Crappily Disguised as a Waiter`)) {
       setChoice(855, 4);
-      adventureMacro($location`The Copperhead Club`, Macro.abort());
+      garboAdventure($location`The Copperhead Club`, Macro.abort());
     }
     freeFightOutfit(toRequirement(freeKill));
     withMacro(
@@ -2450,7 +2450,7 @@ function yachtzee(): void {
 
       setChoice(918, getUMD ? 1 : 2);
 
-      adventureMacroAuto($location`The Sunken Party Yacht`, Macro.abort());
+      garboAdventureAuto($location`The Sunken Party Yacht`, Macro.abort());
       if (
         visitUrl("forestvillage.php").includes("friarcottage.gif") &&
         !get("_floristPlantsUsed").split(",").includes("Crookweed")
@@ -2458,7 +2458,7 @@ function yachtzee(): void {
         cliExecute("florist plant Crookweed");
       }
       if (get("lastEncounter") === "Yacht, See?") {
-        adventureMacroAuto($location`The Sunken Party Yacht`, Macro.abort());
+        garboAdventureAuto($location`The Sunken Party Yacht`, Macro.abort());
       }
       return;
     }

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -77,8 +77,6 @@ import {
   $stat,
   $thrall,
   ActionSource,
-  adventureMacro,
-  adventureMacroAuto,
   AsdonMartin,
   ChateauMantegna,
   clamp,
@@ -106,7 +104,7 @@ import {
 } from "libram";
 import { acquire } from "./acquire";
 import { withStash } from "./clan";
-import { Macro, withMacro } from "./combat";
+import { adventureMacro, adventureMacroAuto, Macro, withMacro } from "./combat";
 import {
   bestFairy,
   freeFightFamiliar,

--- a/src/post.ts
+++ b/src/post.ts
@@ -24,18 +24,17 @@ import {
   $locations,
   $skill,
   $slot,
-  adventureMacro,
   AutumnAton,
   get,
   getRemainingStomach,
   have,
   JuneCleaver,
-  Macro,
   property,
   uneffect,
   withProperty,
 } from "libram";
 import { acquire } from "./acquire";
+import { adventureMacro, Macro } from "./combat";
 import { computeDiet, consumeDiet } from "./diet";
 import {
   bestJuneCleaverOption,

--- a/src/post.ts
+++ b/src/post.ts
@@ -34,7 +34,7 @@ import {
   withProperty,
 } from "libram";
 import { acquire } from "./acquire";
-import { adventureMacro, Macro } from "./combat";
+import { garboAdventure, Macro } from "./combat";
 import { computeDiet, consumeDiet } from "./diet";
 import {
   bestJuneCleaverOption,
@@ -147,7 +147,7 @@ function juneCleave(): void {
     equip($slot`weapon`, $item`June cleaver`);
     skipJuneCleaverChoices();
     withProperty("recoveryScript", "", () => {
-      adventureMacro($location`Noob Cave`, Macro.abort());
+      garboAdventure($location`Noob Cave`, Macro.abort());
       if (["Poetic Justice", "Lost and Found"].includes(get("lastEncounter"))) {
         uneffect($effect`Beaten Up`);
       }

--- a/src/wanderer/index.ts
+++ b/src/wanderer/index.ts
@@ -15,7 +15,7 @@ import {
 import { lovebugsFactory } from "./lovebugs";
 import { yellowRayFactory } from "./yellowray";
 
-export { DraggableFight };
+export type { DraggableFight };
 
 const wanderFactories: WandererFactory[] = [
   defaultFactory,

--- a/src/yachtzee/fishy.ts
+++ b/src/yachtzee/fishy.ts
@@ -10,19 +10,9 @@ import {
   print,
   use,
 } from "kolmafia";
-import {
-  $effect,
-  $item,
-  $location,
-  adventureMacro,
-  get,
-  getActiveEffects,
-  have,
-  Macro,
-  sum,
-  uneffect,
-} from "libram";
+import { $effect, $item, $location, get, getActiveEffects, have, sum, uneffect } from "libram";
 import { acquire } from "../acquire";
+import { adventureMacro, Macro } from "../combat";
 import { maxBy, safeRestore } from "../lib";
 import { pyecAvailable, yachtzeeBuffValue } from "./lib";
 import { getBestWaterBreathingEquipment } from "./outfit";

--- a/src/yachtzee/fishy.ts
+++ b/src/yachtzee/fishy.ts
@@ -12,7 +12,7 @@ import {
 } from "kolmafia";
 import { $effect, $item, $location, get, getActiveEffects, have, sum, uneffect } from "libram";
 import { acquire } from "../acquire";
-import { adventureMacro, Macro } from "../combat";
+import { garboAdventure, Macro } from "../combat";
 import { maxBy, safeRestore } from "../lib";
 import { pyecAvailable, yachtzeeBuffValue } from "./lib";
 import { getBestWaterBreathingEquipment } from "./outfit";
@@ -201,7 +201,7 @@ export function optimizeForFishy(yachtzeeTurns: number, setup?: boolean): number
           use(1, $item`11-leaf clover`);
         }
         if (haveFishyPipe) use(1, $item`fishy pipe`);
-        adventureMacro($location`The Brinier Deepers`, Macro.abort());
+        garboAdventure($location`The Brinier Deepers`, Macro.abort());
         if (get("lastAdventure") !== "The Brinier Deepers") {
           print(
             "We failed to adventure in The Brinier Deepers, even though we thought we could. Try manually adventuring there for a lucky adventure.",

--- a/src/yachtzee/index.ts
+++ b/src/yachtzee/index.ts
@@ -17,14 +17,13 @@ import {
   $item,
   $location,
   $skill,
-  adventureMacro,
   get,
   getActiveSongs,
   have,
-  Macro,
   set,
   uneffect,
 } from "libram";
+import { adventureMacro, Macro } from "../combat";
 import { runDiet } from "../diet";
 import { embezzlerCount } from "../embezzler";
 import { doSausage, freeRunFights } from "../fights";

--- a/src/yachtzee/index.ts
+++ b/src/yachtzee/index.ts
@@ -23,7 +23,7 @@ import {
   set,
   uneffect,
 } from "libram";
-import { adventureMacro, Macro } from "../combat";
+import { garboAdventure, Macro } from "../combat";
 import { runDiet } from "../diet";
 import { embezzlerCount } from "../embezzler";
 import { doSausage, freeRunFights } from "../fights";
@@ -114,7 +114,7 @@ function _yachtzeeChain(): void {
         useSkill($skill`The Polka of Plenty`);
       }
     }
-    adventureMacro($location`The Sunken Party Yacht`, Macro.abort());
+    garboAdventure($location`The Sunken Party Yacht`, Macro.abort());
     postCombatActions();
     if (myTurncount() > turncount || haveEffect($effect`Fishy`) < fishyTurns) {
       fishyTurns -= 1;

--- a/src/yachtzee/lib.ts
+++ b/src/yachtzee/lib.ts
@@ -6,7 +6,6 @@ import {
   $items,
   $location,
   $skill,
-  adventureMacroAuto,
   get,
   getActiveSongs,
   getModifier,
@@ -18,7 +17,7 @@ import {
   tryFindFreeRun,
 } from "libram";
 import { withStash } from "../clan";
-import { Macro } from "../combat";
+import { adventureMacroAuto, Macro } from "../combat";
 import { EmbezzlerFight, embezzlerSources } from "../embezzler";
 import { freeFightFamiliar } from "../familiar";
 import { globalOptions, ltbRun, realmAvailable } from "../lib";

--- a/src/yachtzee/lib.ts
+++ b/src/yachtzee/lib.ts
@@ -17,7 +17,7 @@ import {
   tryFindFreeRun,
 } from "libram";
 import { withStash } from "../clan";
-import { adventureMacroAuto, Macro } from "../combat";
+import { garboAdventureAuto, Macro } from "../combat";
 import { EmbezzlerFight, embezzlerSources } from "../embezzler";
 import { freeFightFamiliar } from "../familiar";
 import { globalOptions, ltbRun, realmAvailable } from "../lib";
@@ -102,7 +102,7 @@ export function useSpikolodonSpikes(): void {
     .step(run.macro);
   const startingSpikes = get("_spikolodonSpikeUses");
   do {
-    adventureMacroAuto(targetZone, macro);
+    garboAdventureAuto(targetZone, macro);
   } while (get("_spikolodonSpikeUses") === startingSpikes);
 
   postCombatActions();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,7 +45,6 @@ const scriptsConfig = merge(
   {
     entry: {
       garbo: "./src/index.ts",
-      "garbo-combat": "./src/combat.ts",
     },
     output: {
       path: path.resolve(__dirname, "KoLmafia", "scripts", "garbage-collector"),


### PR DESCRIPTION
Reparsing garbo-combat.js every non-autoattack adventure takes unnecessary CPU. This approach should cover all cases; it's basically what grimoire does, and we could easily switch from this to full grimoireization.