### PR TITLE
Do all NEP free fights if no Pocket Professor

### DIFF
--- a/src/fights.ts
+++ b/src/fights.ts
@@ -1255,7 +1255,13 @@ const freeFightSources = [
   new FreeFight(
     () =>
       get("neverendingPartyAlways") && questStep("_questPartyFair") < 999
-        ? clamp(10 - get("_neverendingPartyFreeTurns") - (get("_thesisDelivered") ? 0 : 1), 0, 10)
+        ? clamp(
+            10 -
+              get("_neverendingPartyFreeTurns") -
+              (get("_thesisDelivered") || !have($familiar`Pocket Professor`) ? 0 : 1),
+            0,
+            10
+          )
         : 0,
     () => {
       const constructedMacro = Macro.tryHaveSkill($skill`Feel Pride`).basicCombat();


### PR DESCRIPTION
I noticed that I was always leaving 1 free fight on the table. That was because I didn't have a Pocket Professor. This PR fixes that for those of us without one. Thanks Rever for giving me the code for the fix.