### PR TITLE
Get training scrolls from snojo

### DIFF
--- a/src/fights.ts
+++ b/src/fights.ts
@@ -1236,19 +1236,11 @@ const freeFightSources = [
   ),
 
   new FreeFight(
-    () => get("snojoAvailable") && clamp(10 - get("_snojoFreeFights"), 0, 10),
+    () =>
+      get("snojoAvailable") &&
+      get("snojoSetting") !== null &&
+      clamp(10 - get("_snojoFreeFights"), 0, 10),
     () => {
-      const snojoSetting = get("snojoSetting", "NONE");
-      if (snojoSetting === "MYSTICALITY" && get("snojoMysticalityWins") > 50) {
-        visitUrl("place.php?whichplace=snojo&action=snojo_controller");
-        runChoice(3);
-      } else if (snojoSetting === "MUSCLE" && get("snojoMuscleWins") > 50) {
-        visitUrl("place.php?whichplace=snojo&action=snojo_controller");
-        runChoice(2);
-      } else if (snojoSetting === "NONE") {
-        visitUrl("place.php?whichplace=snojo&action=snojo_controller");
-        runChoice(1);
-      }
       adv1($location`The X-32-F Combat Training Snowman`, -1, "");
     },
     false

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -1238,9 +1238,16 @@ const freeFightSources = [
   new FreeFight(
     () => get("snojoAvailable") && clamp(10 - get("_snojoFreeFights"), 0, 10),
     () => {
-      if (get("snojoSetting") === null) {
+      const snojoSetting = get("snojoSetting", "NONE");
+      if (snojoSetting === "MYSTICALITY" && get("snojoMysticalityWins") > 50) {
         visitUrl("place.php?whichplace=snojo&action=snojo_controller");
         runChoice(3);
+      } else if (snojoSetting === "MUSCLE" && get("snojoMuscleWins") > 50) {
+        visitUrl("place.php?whichplace=snojo&action=snojo_controller");
+        runChoice(2);
+      } else if (snojoSetting === "NONE") {
+        visitUrl("place.php?whichplace=snojo&action=snojo_controller");
+        runChoice(1);
       }
       adv1($location`The X-32-F Combat Training Snowman`, -1, "");
     },

--- a/src/tasks/daily.ts
+++ b/src/tasks/daily.ts
@@ -519,7 +519,7 @@ export const DailyTasks: Task[] = [
   {
     name: "Configure Snojo",
     ready: () => get("snojoAvailable") && get("_snojoFreeFights") < 10,
-    completed: () => !snojoConfigured,
+    completed: () => snojoConfigured,
     do: () => configureSnojo(),
   },
   // Final tasks

--- a/src/tasks/daily.ts
+++ b/src/tasks/daily.ts
@@ -63,6 +63,7 @@ const retrieveItems = $items`Half a Purse, seal tooth, The Jokester's gun`;
 let latteRefreshed = false;
 let horseryRefreshed = false;
 let attemptCompletingBarfQuest = true;
+let snojoConfigured = false;
 
 function voterSetup(): void {
   const initPriority: Map<string, number> = new Map([
@@ -292,6 +293,52 @@ function checkBarfQuest(): void {
   return;
 }
 
+export function configureSnojo(): void {
+  if (snojoConfigured) return;
+
+  // if we're ascending, pick whichever consumable has the best price
+  // each consumable takes 7 turns and we can spend 10 per day
+  const options = new Map<number, number>([
+    [(10 / 7) * garboValue($item`ancient medicinal herbs`), 1],
+    [(10 / 7) * garboValue($item`ice rice`), 2],
+    [(10 / 7) * garboValue($item`iced plum wine`), 3],
+  ]);
+  // otherwise, assume we're in for at least five days and consider scrolls
+  // we get 7 consumables in 5 days, plus a scroll
+  if (!globalOptions.ascending) {
+    if (get("snojoMuscleWins") < 50) {
+      options.set(
+        (7 * garboValue($item`ancient medicinal herbs`) +
+          garboValue($item`training scroll:  Shattering Punch`)) /
+          5,
+        1
+      );
+    }
+    if (get("snojoMysticalityWins") < 50) {
+      options.set(
+        (7 * garboValue($item`ice rice`) + garboValue($item`training scroll:  Snokebomb`)) / 5,
+        2
+      );
+    }
+    if (get("snojoMoxieWins") < 50) {
+      options.set(
+        (7 * garboValue($item`iced plum wine`) +
+          garboValue($item`training scroll:  Shivering Monkey Technique`)) /
+          5,
+        3
+      );
+    }
+  }
+
+  const bestProfit = Math.max(...options.keys());
+  const option = options.get(bestProfit);
+  if (option) {
+    visitUrl("place.php?whichplace=snojo&action=snojo_controller");
+    runChoice(option);
+    snojoConfigured = true;
+  }
+}
+
 export const DailyTasks: Task[] = [
   {
     name: "Refresh Latte",
@@ -468,6 +515,12 @@ export const DailyTasks: Task[] = [
     ready: () => get("stenchAirportAlways") || get("_stenchAirportToday"),
     completed: () => !attemptCompletingBarfQuest,
     do: () => checkBarfQuest(),
+  },
+  {
+    name: "Configure Snojo",
+    ready: () => get("snojoAvailable") && get("_snojoFreeFights") < 10,
+    completed: () => !snojoConfigured,
+    do: () => configureSnojo(),
   },
   // Final tasks
   {


### PR DESCRIPTION
Over a long aftercore, you can pick up one of each of the training scrolls from the snojo. Do so.

Implementation is casual, and assumes the user isn't changing the options themselves. It finishes in Moxie, like before.