### PR TITLE
More drop familiars

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "css-loader": "^6.2.0",
     "eslint": "^7.28.0",
     "eslint-config-prettier": "^8.3.0",
-    "eslint-plugin-libram": "^0.2.25",
+    "eslint-plugin-libram": "^0.2.26",
     "mini-css-extract-plugin": "^2.1.0",
     "patch-package": "^6.2.2",
     "prettier": "^2.3.1",

--- a/src/familiar/constantValueFamiliars.ts
+++ b/src/familiar/constantValueFamiliars.ts
@@ -4,6 +4,7 @@ import {
   $familiar,
   $item,
   $items,
+  clamp,
   findLeprechaunMultiplier,
   get,
   getModifier,
@@ -72,19 +73,19 @@ const standardFamiliars: ConstantValueFamiliar[] = [
   },
   {
     familiar: $familiar`Rockin' Robin`,
-    value: () => garboValue($item`robin's egg`) / (30 - get("rockinRobinProgress")),
+    value: () => garboValue($item`robin's egg`) / clamp(30 - get("rockinRobinProgress"), 1, 30),
   },
   {
     familiar: $familiar`Optimistic Candle`,
-    value: () => garboValue($item`glob of melted wax`) / (30 - get("optimisticCandleProgress")),
+    value: () =>
+      garboValue($item`glob of melted wax`) / clamp(30 - get("optimisticCandleProgress"), 1, 30),
   },
   {
     familiar: $familiar`Garbage Fire`,
     value: () =>
       garboAverageValue(
         ...$items`burning newspaper, extra-toasted half sandwich, mulled hobo wine`
-      ) /
-      (30 - get("garbageFireProgress")),
+      ) / clamp(30 - get("garbageFireProgress"), 1, 30),
   },
   {
     familiar: $familiar`Cookbookbat`,

--- a/src/familiar/constantValueFamiliars.ts
+++ b/src/familiar/constantValueFamiliars.ts
@@ -39,7 +39,7 @@ const standardFamiliars: ConstantValueFamiliar[] = [
     value: () =>
       garboAverageValue(
         ...$items`short beer, short stack of pancakes, short stick of butter, short glass of water, short white`
-      ) / 11,
+      ) / 11, // 9 with blue plate
   },
   {
     familiar: $familiar`Robortender`,
@@ -69,6 +69,22 @@ const standardFamiliars: ConstantValueFamiliar[] = [
     // This is the value of getting a pirate costume over getting an amulet coin or whatever
     value: () =>
       have($item`li'l pirate costume`) ? (baseMeat * (300 - bestAlternative)) / 100 : 0,
+  },
+  {
+    familiar: $familiar`Rockin' Robin`,
+    value: () => garboValue($item`robin's egg`) / (30 - get("rockinRobinProgress")),
+  },
+  {
+    familiar: $familiar`Optimistic Candle`,
+    value: () => garboValue($item`glob of melted wax`) / (30 - get("optimisticCandleProgress")),
+  },
+  {
+    familiar: $familiar`Garbage Fire`,
+    value: () =>
+      garboAverageValue(
+        ...$items`burning newspaper, extra-toasted half sandwich, mulled hobo wine`
+      ) /
+      (30 - get("garbageFireProgress")),
   },
   {
     familiar: $familiar`Cookbookbat`,

--- a/src/familiar/dropFamiliars.ts
+++ b/src/familiar/dropFamiliars.ts
@@ -155,10 +155,8 @@ const rotatingFamiliars: StandardDropFamiliar[] = [
       11,
   },
   {
-    // eslint-disable-next-line libram/verify-constants
     familiar: $familiar`Hobo in Sheep's Clothing`,
     expected: (i) => 5 * (i ** 2 + 3 * i + 2), // faster with half-height cigar
-    // eslint-disable-next-line libram/verify-constants
     drop: $item`grubby wool`,
   },
 ];

--- a/src/familiar/dropFamiliars.ts
+++ b/src/familiar/dropFamiliars.ts
@@ -156,7 +156,7 @@ const rotatingFamiliars: StandardDropFamiliar[] = [
   },
   {
     familiar: $familiar`Hobo in Sheep's Clothing`,
-    expected: (i) => 5 * (i ** 2 + 3 * i + 2), // faster with half-height cigar
+    expected: (i) => 10 * i + 10, // faster with half-height cigar
     drop: $item`grubby wool`,
   },
 ];

--- a/src/familiar/dropFamiliars.ts
+++ b/src/familiar/dropFamiliars.ts
@@ -1,5 +1,5 @@
 import { Familiar, Item } from "kolmafia";
-import { $familiar, $item, $items, findLeprechaunMultiplier, have } from "libram";
+import { $familiar, $item, $items, findLeprechaunMultiplier, get, have } from "libram";
 import { garboAverageValue, garboValue } from "../session";
 import { GeneralFamiliar } from "./lib";
 
@@ -156,13 +156,22 @@ const rotatingFamiliars: StandardDropFamiliar[] = [
   },
   {
     familiar: $familiar`Rockin' Robin`,
-    expected: (i) => (i === 0 ? 5 : 30),
+    expected: () => (30 - get("rockinRobinProgress")),
     drop: $item`robin's egg`,
   },
   {
     familiar: $familiar`Optimistic Candle`,
-    expected: (i) => (i === 0 ? 5 : 30),
+    expected: () => (30 - get("optimisticCandleProgress")),
     drop: $item`glob of melted wax`,
+  },
+  {
+    familiar: $familiar`Garbage Fire`,
+    expected: () => (30 - get("garbageFireProgress")),
+    drop: [
+      $item`burning newspaper`,
+      $item`extra-toasted half sandwich`,
+      $item`mulled hobo wine`,
+    ]
   },
   {
     familiar: $familiar`Shorter-Order Cook`,

--- a/src/familiar/dropFamiliars.ts
+++ b/src/familiar/dropFamiliars.ts
@@ -3,6 +3,11 @@ import { $familiar, $item, $items, findLeprechaunMultiplier, get, have } from "l
 import { garboAverageValue, garboValue } from "../session";
 import { GeneralFamiliar } from "./lib";
 
+// load these once when module is first loaded
+const rockinRobinProgress = get("rockinRobinProgress");
+const optimisticCandleProgress = get("optimisticCandleProgress");
+const garbageFireProgress = get("garbageFireProgress");
+
 type StandardDropFamiliar = {
   familiar: Familiar;
   expected: number[] | ((index: number) => number);
@@ -156,17 +161,17 @@ const rotatingFamiliars: StandardDropFamiliar[] = [
   },
   {
     familiar: $familiar`Rockin' Robin`,
-    expected: () => (30 - get("rockinRobinProgress")),
+    expected: (i) => (i === 0 ? 30 - rockinRobinProgress : 30),
     drop: $item`robin's egg`,
   },
   {
     familiar: $familiar`Optimistic Candle`,
-    expected: () => (30 - get("optimisticCandleProgress")),
+    expected: (i) => (i === 0 ? 30 - optimisticCandleProgress : 30),
     drop: $item`glob of melted wax`,
   },
   {
     familiar: $familiar`Garbage Fire`,
-    expected: () => (30 - get("garbageFireProgress")),
+    expected: (i) => (i === 0 ? 30 - garbageFireProgress : 30),
     drop: [
       $item`burning newspaper`,
       $item`extra-toasted half sandwich`,

--- a/src/familiar/dropFamiliars.ts
+++ b/src/familiar/dropFamiliars.ts
@@ -1,12 +1,7 @@
 import { Familiar, Item } from "kolmafia";
-import { $familiar, $item, $items, findLeprechaunMultiplier, get, have } from "libram";
+import { $familiar, $item, $items, findLeprechaunMultiplier, have } from "libram";
 import { garboAverageValue, garboValue } from "../session";
 import { GeneralFamiliar } from "./lib";
-
-// load these once when module is first loaded
-const rockinRobinProgress = get("rockinRobinProgress");
-const optimisticCandleProgress = get("optimisticCandleProgress");
-const garbageFireProgress = get("garbageFireProgress");
 
 type StandardDropFamiliar = {
   familiar: Familiar;
@@ -160,36 +155,6 @@ const rotatingFamiliars: StandardDropFamiliar[] = [
       11,
   },
   {
-    familiar: $familiar`Rockin' Robin`,
-    expected: (i) => (i === 0 ? 30 - rockinRobinProgress : 30),
-    drop: $item`robin's egg`,
-  },
-  {
-    familiar: $familiar`Optimistic Candle`,
-    expected: (i) => (i === 0 ? 30 - optimisticCandleProgress : 30),
-    drop: $item`glob of melted wax`,
-  },
-  {
-    familiar: $familiar`Garbage Fire`,
-    expected: (i) => (i === 0 ? 30 - garbageFireProgress : 30),
-    drop: [
-      $item`burning newspaper`,
-      $item`extra-toasted half sandwich`,
-      $item`mulled hobo wine`,
-    ]
-  },
-  {
-    familiar: $familiar`Shorter-Order Cook`,
-    expected: () => 11, // 9 with blue plate equipped
-    drop: [
-      $item`short stack of pancakes`,
-      $item`short stick of butter`,
-      $item`short glass of water`,
-      $item`short white`,
-      $item`short beer`,
-    ],
-  },
-  {
     // eslint-disable-next-line libram/verify-constants
     familiar: $familiar`Hobo in Sheep's Clothing`,
     expected: (i) => 5 * (i ** 2 + 3 * i + 2), // faster with half-height cigar
@@ -216,7 +181,8 @@ export function getAllDrops(fam: Familiar): { expectedValue: number; expectedTur
   const current = fam.dropsToday;
   const returnValue = [];
 
-  for (let i = current; i < expected.length; i++) {
+  const length = Array.isArray(expected) ? expected.length : 11; // 11 seems a reasonable max
+  for (let i = current; i < length; i++) {
     const turns = expectedTurnsValue(target.expected, i);
     returnValue.push({
       expectedValue: dropValue(drop) / turns + (additionalValue?.() ?? 0),

--- a/src/familiar/dropFamiliars.ts
+++ b/src/familiar/dropFamiliars.ts
@@ -190,8 +190,10 @@ const rotatingFamiliars: StandardDropFamiliar[] = [
     ],
   },
   {
+    // eslint-disable-next-line libram/verify-constants
     familiar: $familiar`Hobo in Sheep's Clothing`,
     expected: (i) => 5 * (i ** 2 + 3 * i + 2), // faster with half-height cigar
+    // eslint-disable-next-line libram/verify-constants
     drop: $item`grubby wool`,
   },
 ];

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -803,7 +803,6 @@ const freeFightSources = [
             get("lovebugsUnlocked"),
             Macro.trySkill($skill`Summon Love Gnats`).trySkill($skill`Summon Love Mosquito`)
           )
-          // eslint-disable-next-line libram/verify-constants
           .tryItem($item`train whistle`)
           .trySkill($skill`Micrometeorite`)
           .tryItem($item`Time-Spinner`)
@@ -1291,7 +1290,6 @@ const freeFightSources = [
 
   new FreeFight(
     () => (get("ownsSpeakeasy") ? 3 - get("_speakeasyFreeFights") : 0),
-    // eslint-disable-next-line libram/verify-constants
     () => adv1($location`An Unusually Quiet Barroom Brawl`, -1, ""),
     true
   ),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2172,7 +2172,7 @@ eslint-config-prettier@^8.3.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz#f7471b20b6fe8a9a9254cc684454202886a2dd7a"
   integrity sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==
 
-eslint-plugin-libram@^0.2.25:
+eslint-plugin-libram@^0.2.26:
   version "0.2.26"
   resolved "https://registry.yarnpkg.com/eslint-plugin-libram/-/eslint-plugin-libram-0.2.26.tgz#dd7e615d9daea8d3ccc2a9f378897fa8c0e42275"
   integrity sha512-z1v9bu2p+ICw84JmT8Ha10b9zq77V1ndMjEiJfZxv5RqrPmzHzGVcoGpYOneUqK+6kaAh9tRcry+4I5O05JUEg==


### PR DESCRIPTION
Add Rockin' Robin, Optimistic Candle, Garbage Fire, Shorter-Order Cook and Sheep. Crash the wool market!

Not certain expected is in the right format but it should be close.

Don't know how to get the blue plate checked (and later the cigar, after how it affects drops gets spaded). One possibility is we always assume you're equipping it and just buy it if necessary. That's probably simplest.

The XO Skeleton is another interesting one that could be added, but it doesn't really fit with the existing framework: it drops both Xs and Os, roughly 9 turns each, overlapping. You could approximate it with X + O / 2 every 4.5 turns, but that's not quite right.