### PR TITLE
Try singing along as the first combat action

### DIFF
--- a/src/combat.ts
+++ b/src/combat.ts
@@ -279,8 +279,8 @@ export class Macro extends StrictMacro {
       shouldRedigitize(),
       Macro.if_($monster`Knob Goblin Embezzler`, Macro.trySkill($skill`Digitize`))
     )
-      .familiarActions()
       .tryHaveSkill($skill`Sing Along`)
+      .familiarActions()
       .externalIf(
         digitizedMonstersRemaining() <= 5 - get("_meteorShowerUses") &&
           have($skill`Meteor Lore`) &&


### PR DESCRIPTION
While this is a bandaid fix to the Extract Jelly bug, it is also consistent with startCombat() which also does Sing Along before familiar actions. Unfortunately, if the user has a jellyfish but no boombox (a rare Guy I'm assuming), this fix does nothing for them.