### PR TITLE
feat: if quick mode enabled, don't stasis for as long

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ _EXPERIMENTAL_ Garbo will sacrifice some optimal behaviors to run quicker. Estim
 - Many non-critical mall searches will instead check historical price with a max age of 1 week.
 - `maximizerCombinationLimit` will be set to 100000.
 - [Brimstone equipment](https://kol.coldfront.net/thekolwiki/index.php/Blasphemous_Bedizenment) will be ignored by the maximizer to reduce possible combinations.
+- Stasis at max 5 rounds, instead of up to 20.
 
 ### Turncount
 

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -55,6 +55,7 @@ import {
   SourceTerminal,
   StrictMacro,
 } from "libram";
+import { globalOptions } from "./config";
 import { canOpenRedPresent, meatFamiliar, timeToMeatify } from "./familiar";
 import { digitizedMonstersRemaining } from "./turns";
 
@@ -399,6 +400,11 @@ export class Macro extends StrictMacro {
     ) {
       // These things can take a little longer to proc sometimes
       stasisRounds = 20;
+    }
+
+    if (globalOptions.quick) {
+      // long fights can be very slow
+      stasisRounds = Math.min(5, stasisRounds);
     }
 
     // Ignore unexpected monsters, holiday scaling monsters seem to abort with monsterhpabove


### PR DESCRIPTION
Stasising for 20 rounds can drastically increase how long garbo takes to run for incremental gains. In quick mode, don't.

Some of the causes for 20 round stasis are questionable -- I think BittyCar only happens after the first round, and many crown / bjorn drops only in the first 3 rounds -- but I left them as they were.