### PR TITLE
Backup safe list

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -372,13 +372,44 @@ export function main(argString = ""): void {
       1341: 1, // Cure her poison
     });
 
+    const quartetChoice = get("lastQuartetRequest", 0) !== 0 ? get("lastQuartetRequest") : 4;
     // Non-combat options for backup wanderer locations
     propertyManager.setChoices({
-      522: 2, // Cobb's Knob Barracks, skip
-      1107: 1, // tennis ball
-      1108: bestHalloweiner,
-      1340: 1, // Accept the doctor quest
-      1341: 1, // Cure her poison
+      // Cobb's Knob Barracks
+      522: 2, // Skip
+      // The Castle in the Clouds in the Sky (Basement)
+      669: 1, // Neckbeard choice
+      670: 4, // Skip
+      671: 4, // Fitness choice
+      // The Castle in the Clouds in the Sky (Ground Floor)
+      672: 3, // Skip
+      673: 3, // Skip
+      674: 3, // Skip
+      1026: 3, // Skip
+      // The Castle in the Clouds in the Sky (Top Floor)
+      675: 4, // Steampunk choice
+      676: 4, // Punk Rock choice
+      677: 1, // Fight Steam Punk Giant
+      678: 3, // Steampunk choice
+      // The Penultimate Fantasy Airship
+      182: 1, // Fight random enemy
+      178: 2, // Skip
+      // The Haunted Gallery
+      91: 2, // Skip
+      89: 6, // Skip
+      // The Haunted Library
+      163: 4, // Skip
+      888: 4, // Skip
+      889: 5, // Skip
+      // The Haunted Ballroom
+      106: 3, // Skip
+      90: quartetChoice, // Choose currently playing song, or skip
+      // The Haiku Dungeon
+      297: 3, // Skip
+      // A Mob of Zeppelin Protesters - Probably unecessary, these shouldn't show up after ascension is complete
+      856: 2, // Skip
+      857: 2, // Skip
+      858: 2, // Skip
     });
 
     if (JuneCleaver.have()) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -372,46 +372,6 @@ export function main(argString = ""): void {
       1341: 1, // Cure her poison
     });
 
-    const quartetChoice = get("lastQuartetRequest", 0) !== 0 ? get("lastQuartetRequest") : 4;
-    // Non-combat options for backup wanderer locations
-    propertyManager.setChoices({
-      // Cobb's Knob Barracks
-      522: 2, // Skip
-      // The Castle in the Clouds in the Sky (Basement)
-      669: 1, // Neckbeard choice
-      670: 4, // Skip
-      671: 4, // Fitness choice
-      // The Castle in the Clouds in the Sky (Ground Floor)
-      672: 3, // Skip
-      673: 3, // Skip
-      674: 3, // Skip
-      1026: 3, // Skip
-      // The Castle in the Clouds in the Sky (Top Floor)
-      675: 4, // Steampunk choice
-      676: 4, // Punk Rock choice
-      677: 1, // Fight Steam Punk Giant
-      678: 3, // Steampunk choice
-      // The Penultimate Fantasy Airship
-      182: 1, // Fight random enemy
-      178: 2, // Skip
-      // The Haunted Gallery
-      91: 2, // Skip
-      89: 6, // Skip
-      // The Haunted Library
-      163: 4, // Skip
-      888: 4, // Skip
-      889: 5, // Skip
-      // The Haunted Ballroom
-      106: 3, // Skip
-      90: quartetChoice, // Choose currently playing song, or skip
-      // The Haiku Dungeon
-      297: 3, // Skip
-      // A Mob of Zeppelin Protesters - Probably unecessary, these shouldn't show up after ascension is complete
-      856: 2, // Skip
-      857: 2, // Skip
-      858: 2, // Skip
-    });
-
     if (JuneCleaver.have()) {
       propertyManager.setChoices(
         Object.fromEntries(

--- a/src/index.ts
+++ b/src/index.ts
@@ -372,6 +372,15 @@ export function main(argString = ""): void {
       1341: 1, // Cure her poison
     });
 
+    // Non-combat options for backup wanderer locations
+    propertyManager.setChoices({
+      522: 2, // Cobb's Knob Barracks, skip
+      1107: 1, // tennis ball
+      1108: bestHalloweiner,
+      1340: 1, // Accept the doctor quest
+      1341: 1, // Cure her poison
+    });
+
     if (JuneCleaver.have()) {
       propertyManager.setChoices(
         Object.fromEntries(

--- a/src/wanderer/lib.ts
+++ b/src/wanderer/lib.ts
@@ -84,7 +84,7 @@ export function unlock(loc: Location, value: number): boolean {
 
 const backupSkiplist = $locations`The Overgrown Lot, The Skeleton Store, The Mansion of Dr. Weirdeaux`;
 // These are locations where all non-combats have skips or lead to a combat.
-const backupSafelist = $locations`The Haunted Gallery, The Haunted Ballroom, The Haunted Library, The Haunted Billiards Room, The Penultimate Fantasy Airship, Cobb's Knob Barracks, The Castle in the Clouds in the Sky (Basement), The Castle in the Clouds in the Sky (Ground Floor), The Castle in the Clouds in the Sky (Top Floor), The Haiku Dungeon, Twin Peak`;
+const backupSafelist = $locations`The Haunted Gallery, The Haunted Ballroom, The Haunted Library, The Haunted Billiards Room, The Penultimate Fantasy Airship, Cobb's Knob Barracks, The Castle in the Clouds in the Sky (Basement), The Castle in the Clouds in the Sky (Ground Floor), The Castle in the Clouds in the Sky (Top Floor), The Haiku Dungeon, Twin Peak, A Mob of Zeppelin Protesters`;
 function canWanderTypeBackup(location: Location): boolean {
   return (
     !backupSkiplist.includes(location) &&

--- a/src/wanderer/lib.ts
+++ b/src/wanderer/lib.ts
@@ -83,8 +83,11 @@ export function unlock(loc: Location, value: number): boolean {
 }
 
 const backupSkiplist = $locations`The Overgrown Lot, The Skeleton Store, The Mansion of Dr. Weirdeaux`;
+
 // These are locations where all non-combats have skips or lead to a combat.
 const backupSafelist = $locations`The Haunted Gallery, The Haunted Ballroom, The Haunted Library, The Penultimate Fantasy Airship, Cobb's Knob Barracks, The Castle in the Clouds in the Sky (Basement), The Castle in the Clouds in the Sky (Ground Floor), The Castle in the Clouds in the Sky (Top Floor), The Haiku Dungeon, Twin Peak, A Mob of Zeppelin Protesters`;
+// These are locations where all non-combats are skippable
+const yellowRaySafelist = $locations`The Haunted Gallery, The Haunted Ballroom, The Haunted Library, Cobb's Knob Barracks, The Castle in the Clouds in the Sky (Basement), The Castle in the Clouds in the Sky (Ground Floor), The Haiku Dungeon, Twin Peak, A Mob of Zeppelin Protesters`;
 function canWanderTypeBackup(location: Location): boolean {
   return (
     !backupSkiplist.includes(location) &&
@@ -96,7 +99,10 @@ function canWanderTypeYellowRay(location: Location): boolean {
   if (location === $location`The Fun-Guy Mansion` && get("funGuyMansionKills", 0) >= 100) {
     return false;
   }
-  return canWanderTypeBackup(location);
+  return (
+    !backupSkiplist.includes(location) &&
+    (location.combatPercent >= 100 || yellowRaySafelist.includes(location))
+  );
 }
 
 const wandererSkiplist = $locations`The Batrat and Ratbat Burrow, Guano Junction, The Beanbat Chamber, A-Boo Peak`;
@@ -147,6 +153,7 @@ export type WandererFactory = (
 ) => WandererTarget[];
 export type WandererLocation = { location: Location; targets: WandererTarget[]; value: number };
 
+const quartetChoice = get("lastQuartetRequest", 0) !== 0 ? get("lastQuartetRequest") : 4;
 export const unsupportedChoices = new Map<Location, { [choice: number]: number | string }>([
   [$location`The Spooky Forest`, { [502]: 2, [505]: 2 }],
   [$location`Guano Junction`, { [1427]: 1 }],
@@ -156,8 +163,11 @@ export const unsupportedChoices = new Map<Location, { [choice: number]: number |
   [$location`The Haunted Laboratory`, { [884]: 6 }],
   [$location`The Haunted Nursery`, { [885]: 6 }],
   [$location`The Haunted Storage Room`, { [886]: 6 }],
+  [$location`The Haunted Ballroom`, { [106]: 3, [90]: quartetChoice }], // Skip, and Choose currently playing song, or skip
+  [$location`The Haunted Library`, { [163]: 4, [888]: 4, [889]: 5 }],
+  [$location`The Haunted Gallery`, { [89]: 6, [91]: 2 }],
   [$location`The Hidden Park`, { [789]: 6 }],
-  [$location`A Mob of Zeppelin Protesters`, { [1432]: 1, [857]: 2 }],
+  [$location`A Mob of Zeppelin Protesters`, { [1432]: 1, [856]: 2, [857]: 2, [858]: 2 }],
   [$location`A-Boo Peak`, { [1430]: 2 }],
   [$location`Sloppy Seconds Diner`, { [919]: 6 }],
   [$location`VYKEA`, { [1115]: 6 }],
@@ -181,8 +191,29 @@ export const unsupportedChoices = new Map<Location, { [choice: number]: number |
   ],
   [$location`The Copperhead Club`, { [855]: 4 }],
   [$location`The Haunted Bathroom`, { [882]: 2 }], // skip; it's the towel adventure but we don't want towels
-  [$location`The Castle in the Clouds in the Sky (Top Floor)`, { [1431]: 1, [677]: 2 }],
+  [
+    $location`The Castle in the Clouds in the Sky (Top Floor)`,
+    {
+      [1431]: 1,
+      [675]: 4, // Go to Steampunk choice
+      [676]: 4, // Go to Punk Rock choice
+      [677]: 1, // Fight Steam Punk Giant
+      [678]: 3, // Go to Steampunk choice
+    },
+  ],
+  [
+    $location`The Castle in the Clouds in the Sky (Ground Floor)`,
+    {
+      [672]: 3, // Skip
+      [673]: 3, // Skip
+      [674]: 3, // Skip
+      [1026]: 3, // Skip
+    },
+  ],
   [$location`The Hidden Office Building`, { [786]: 6 }],
+  [$location`Cobb's Knob Barracks`, { [522]: 6 }], // skip
+  [$location`The Penultimate Fantasy Airship`, { [178]: 2, [182]: 1 }], // Skip, and Fight random enemy
+  [$location`The Haiku Dungeon`, { [297]: 3 }], // skip
 ]);
 
 export function defaultFactory(): WandererTarget[] {

--- a/src/wanderer/lib.ts
+++ b/src/wanderer/lib.ts
@@ -84,7 +84,7 @@ export function unlock(loc: Location, value: number): boolean {
 
 const backupSkiplist = $locations`The Overgrown Lot, The Skeleton Store, The Mansion of Dr. Weirdeaux`;
 // These are locations where all non-combats have skips or lead to a combat.
-const backupSafelist = $locations`The Haunted Gallery, The Haunted Ballroom, The Haunted Library, The Haunted Billiards Room, The Penultimate Fantasy Airship, Cobb's Knob Barracks, The Castle in the Clouds in the Sky (Basement), The Castle in the Clouds in the Sky (Ground Floor), The Castle in the Clouds in the Sky (Top Floor), The Haiku Dungeon, Twin Peak, A Mob of Zeppelin Protesters`;
+const backupSafelist = $locations`The Haunted Gallery, The Haunted Ballroom, The Haunted Library, The Penultimate Fantasy Airship, Cobb's Knob Barracks, The Castle in the Clouds in the Sky (Basement), The Castle in the Clouds in the Sky (Ground Floor), The Castle in the Clouds in the Sky (Top Floor), The Haiku Dungeon, Twin Peak, A Mob of Zeppelin Protesters`;
 function canWanderTypeBackup(location: Location): boolean {
   return (
     !backupSkiplist.includes(location) &&

--- a/src/wanderer/lib.ts
+++ b/src/wanderer/lib.ts
@@ -83,8 +83,13 @@ export function unlock(loc: Location, value: number): boolean {
 }
 
 const backupSkiplist = $locations`The Overgrown Lot, The Skeleton Store, The Mansion of Dr. Weirdeaux`;
+// These are locations where all non-combats have skips or lead to a combat.
+const backupSafelist = $locations`The Haunted Gallery, The Haunted Bathroom, The Haunted Library, The Haunted Billiards Room, The Penultimate Fantasy Airship, Cobb's Knob Barracks, The Castle in the Clouds in the Sky (Basement), The Castle in the Clouds in the Sky (Ground Floor), The Castle in the Clouds in the Sky (Top Floor), The Haiku Dungeon, Twin Peak`;
 function canWanderTypeBackup(location: Location): boolean {
-  return !backupSkiplist.includes(location) && location.combatPercent >= 100;
+  return (
+    !backupSkiplist.includes(location) &&
+    (location.combatPercent >= 100 || backupSafelist.includes(location))
+  );
 }
 
 function canWanderTypeYellowRay(location: Location): boolean {

--- a/src/wanderer/lib.ts
+++ b/src/wanderer/lib.ts
@@ -84,7 +84,7 @@ export function unlock(loc: Location, value: number): boolean {
 
 const backupSkiplist = $locations`The Overgrown Lot, The Skeleton Store, The Mansion of Dr. Weirdeaux`;
 // These are locations where all non-combats have skips or lead to a combat.
-const backupSafelist = $locations`The Haunted Gallery, The Haunted Bathroom, The Haunted Library, The Haunted Billiards Room, The Penultimate Fantasy Airship, Cobb's Knob Barracks, The Castle in the Clouds in the Sky (Basement), The Castle in the Clouds in the Sky (Ground Floor), The Castle in the Clouds in the Sky (Top Floor), The Haiku Dungeon, Twin Peak`;
+const backupSafelist = $locations`The Haunted Gallery, The Haunted Ballroom, The Haunted Library, The Haunted Billiards Room, The Penultimate Fantasy Airship, Cobb's Knob Barracks, The Castle in the Clouds in the Sky (Basement), The Castle in the Clouds in the Sky (Ground Floor), The Castle in the Clouds in the Sky (Top Floor), The Haiku Dungeon, Twin Peak`;
 function canWanderTypeBackup(location: Location): boolean {
   return (
     !backupSkiplist.includes(location) &&


### PR DESCRIPTION
This allows us to wander in locations that are safe to backup in because all NCs in the area are skippable or lead to a combat.

Unfortunately I cannot test this within normal garbo, I do not have guzzlr. I have however been running essentially this with a custom garbo that does Doc Bag locations and has been working well.

I'm not 100% happy the way I'm setting the choice option properties right now (Just always setting them in main), but I have yet to come up with a better answer.



**Locations that we may also consider later for long aftercore (or if there is some way to know whether we have already encountered one-time adventures this ascension):**
- The Sleazy Back Alley
- The Haunted Pantry
- The Outskirts of Cobb's Knob 

**Locations we may consider with additional handling:**
- Madness Bakery (Only if you have enough ingredients to make popular tarts, have done the quest, and creating popular tarts is meat positive)
- The Haunted Billiards Room (Only safe if you already have a pool cue. Possibly unsafe if stolen via pvp etc)

**Locations that may still be profitable to wander in despite NCs (Demon name superlikelies that are 1/150 chance)**
- The Haunted Bathroom 
- The Spooky Forest
- Pandamonium Slums (Also has a one-time adventure)
