### PR TITLE
Don't wander at Professor Jacking's Huge-A-Ma-tron

### DIFF
--- a/src/wanderer/lib.ts
+++ b/src/wanderer/lib.ts
@@ -82,7 +82,7 @@ export function unlock(loc: Location, value: number): boolean {
   return use(unlockableZone.unlocker);
 }
 
-const backupSkiplist = $locations`The Overgrown Lot, The Skeleton Store, The Mansion of Dr. Weirdeaux`;
+const backupSkiplist = $locations`The Overgrown Lot, The Skeleton Store, The Mansion of Dr. Weirdeaux, Professor Jacking's Huge-A-Ma-tron`;
 
 // These are locations where all non-combats have skips or lead to a combat.
 const backupSafelist = $locations`The Haunted Gallery, The Haunted Ballroom, The Haunted Library, The Penultimate Fantasy Airship, Cobb's Knob Barracks, The Castle in the Clouds in the Sky (Basement), The Castle in the Clouds in the Sky (Ground Floor), The Castle in the Clouds in the Sky (Top Floor), The Haiku Dungeon, Twin Peak, A Mob of Zeppelin Protesters`;


### PR DESCRIPTION
The Whole Kingdom combat resulting from the noncombat can't be instakilled and the noncombat is not skippable otherwise it seems.