### PR TITLE
Allow using a custom Combat Macro for Shadow Rift

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -190,6 +190,12 @@ You can use multiple options in conjunction, e.g. "garbo nobarf ascend"',
           help: "If you're a very high level, what HP threshold should garbo aim to maintain?",
           default: 2000,
         }),
+        shadowRiftMacro: Args.string({
+          setting: "garbo_shadowRiftCombatMacro",
+          help: "If set, garbo will use this combat macro when adventuring in the Shadow Rift. Leave blank to disable",
+          default: "",
+          hidden: true,
+        }),
       }
     ),
     /*

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -1409,13 +1409,13 @@ const freeFightSources = [
       if (!get("_shadowAffinityToday") && !ClosedCircuitPayphone.rufusTarget()) {
         ClosedCircuitPayphone.chooseQuest(() => 2); // Choose an artifact (not supporting boss for now)
       }
-      adv1(bestShadowRift(), -1, "");
+      adv1(bestShadowRift(), -1, globalOptions.prefs.shadowRiftMacro);
 
       if (get("encountersUntilSRChoice", 0) === 0) {
         if (ClosedCircuitPayphone.have() && !ClosedCircuitPayphone.rufusTarget()) {
           ClosedCircuitPayphone.chooseQuest(() => 2);
         }
-        adv1(bestShadowRift(), -1, ""); // grab the NC
+        adv1(bestShadowRift(), -1, globalOptions.prefs.shadowRiftMacro); // grab the NC
       }
 
       if (questStep("questRufus") === 1) {


### PR DESCRIPTION
Configure this if the default garbo CCS is failing to kill monsters in the Shadow Rift. TheKolWiki has details about how to write a macro: https://kol.coldfront.net/thekolwiki/index.php/Combat_Macros