### PR TITLE
1st phase Chibibuddy implementation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -102,7 +102,7 @@ export function canContinue(): boolean {
 }
 
 export function main(argString = ""): void {
-  sinceKolmafiaRevision(27339);
+  sinceKolmafiaRevision(27360);
   checkGithubVersion();
 
   // Hit up main.php to get out of easily escapable choices

--- a/src/tasks/daily.ts
+++ b/src/tasks/daily.ts
@@ -192,8 +192,6 @@ function chibiSetup(): void {
       runChoice(7);
     }
   }
-  // Mafia does not currently see the item change if our buddy died
-  cliExecute("refresh inventory");
   // If we only have an (off) chibibuddy (whether from the beginning, or we just turned it off)
   // Turn it back on and confirm availability of the buff
   if (have($item`ChibiBuddy™ (off)`) && !have($item`ChibiBuddy™ (on)`)) {
@@ -400,8 +398,10 @@ export function configureSnojo(): void {
 export const DailyTasks: Task[] = [
   {
     name: "Chibi Buddy",
-    ready: () => have($item`ChibiBuddy™ (on)`) || have($item`ChibiBuddy™ (off)`),
-    completed: () => have($effect`ChibiChanged™`),
+    ready: () =>
+      get("_chibiChanged", true) &&
+      (have($item`ChibiBuddy™ (on)`) || have($item`ChibiBuddy™ (off)`)),
+    completed: () => get("_chibiChanged", true),
     do: chibiSetup,
     limit: { soft: 1 },
   },

--- a/src/tasks/daily.ts
+++ b/src/tasks/daily.ts
@@ -185,6 +185,7 @@ function chibiSetup(): void {
       // This is the choice option for chibi chat
       if (availableChoiceOptions()[5]) {
         runChoice(5);
+        runChoice(7);
         return;
       }
       // Exit the choice, if our buddy died, this will give us back a buddy (off)
@@ -206,7 +207,6 @@ function chibiSetup(): void {
     if (handlingChoice()) {
       if (availableChoiceOptions()[5]) {
         runChoice(5);
-        return;
       }
       runChoice(7);
     }

--- a/src/tasks/daily.ts
+++ b/src/tasks/daily.ts
@@ -1,7 +1,6 @@
 import { Task } from "grimoire-kolmafia";
 import {
   adv1,
-  availableChoiceOptions,
   canadiaAvailable,
   canAdventure,
   canEquip,
@@ -44,7 +43,6 @@ import {
   $monster,
   $slot,
   BeachComb,
-  directlyUse,
   findLeprechaunMultiplier,
   get,
   getModifier,

--- a/src/tasks/daily.ts
+++ b/src/tasks/daily.ts
@@ -170,37 +170,12 @@ function chibiBuffAvailable(): boolean {
   if (!have($item`ChibiBuddy™ (on)`) && !have($item`ChibiBuddy™ (off)`)) return false;
   // We need to name our buddy when we turn it on!
   const chibiNames = [
-    "Oliver",
-    "Neil",
-    "William",
-    "Guillermo",
-    "Aaron",
-    "Isobel",
-    "Pope Gregory",
-    "Harvey Keitel",
-    "Angel Olsen",
-    "The Olsen Twins",
-    "Maryam Mirzakhani",
-    "Shrek",
-    "Donkey",
-    "Fiona",
-    "Fargus",
     "SSBBHax",
     "Frasier Crane",
-    "Brendan Fraser",
-    "Professor Plum",
-    "John H. Conway",
-    "John B. Conway",
-    "Butts McGruff",
-    "Samuel Gaus",
+    "William",
     "Gamuel Sauce",
     "Axis Shadowbaenimus",
     "Dale Cooper",
-    "G",
-    "Twink",
-    "Alice",
-    "Mädchen Amick",
-    "Peter Falk",
   ];
   // It is possible our Buddy died after rollover, and will turn to (off) after using it
   // It is also possible we ascended with a Buddy(on) in which case it will reset immediately without the choice adventure on use

--- a/src/tasks/daily.ts
+++ b/src/tasks/daily.ts
@@ -166,51 +166,6 @@ function voterSetup(): void {
   visitUrl(`choice.php?option=1&whichchoice=1331&g=${monsterVote}&local[]=${init}&local[]=${init}`);
 }
 
-function chibiSetup(): void {
-  if (!have($item`ChibiBuddy™ (on)`) && !have($item`ChibiBuddy™ (off)`)) return;
-  // We need to name our buddy when we turn it on!
-  const chibiNames = [
-    "SSBBHax",
-    "Frasier Crane",
-    "William",
-    "Gamuel Sauce",
-    "Axis Shadowbaenimus",
-    "Dale Cooper",
-  ];
-  // It is possible our Buddy died after rollover, and will turn to (off) after using it
-  // It is also possible we ascended with a Buddy(on) in which case it will reset immediately without the choice adventure on use
-  if (have($item`ChibiBuddy™ (on)`)) {
-    directlyUse($item`ChibiBuddy™ (on)`);
-    if (handlingChoice()) {
-      // This is the choice option for chibi chat
-      if (availableChoiceOptions()[5]) {
-        runChoice(5);
-        runChoice(7);
-        return;
-      }
-      // Exit the choice, if our buddy died, this will give us back a buddy (off)
-      runChoice(7);
-    }
-  }
-  // If we only have an (off) chibibuddy (whether from the beginning, or we just turned it off)
-  // Turn it back on and confirm availability of the buff
-  if (have($item`ChibiBuddy™ (off)`) && !have($item`ChibiBuddy™ (on)`)) {
-    directlyUse($item`ChibiBuddy™ (off)`);
-    if (handlingChoice()) {
-      // Naming
-      const chibiName = chibiNames[Math.floor(Math.random() * chibiNames.length)];
-      runChoice(1, `&chibiname=${chibiName}`);
-    }
-    // We should now have our fresh buddy
-    if (handlingChoice()) {
-      if (availableChoiceOptions()[5]) {
-        runChoice(5);
-      }
-      runChoice(7);
-    }
-  }
-}
-
 function pantogram(): void {
   if (!Pantogram.have() || Pantogram.havePants()) return;
   let pantogramValue: number;
@@ -398,11 +353,9 @@ export function configureSnojo(): void {
 export const DailyTasks: Task[] = [
   {
     name: "Chibi Buddy",
-    ready: () =>
-      !get("_chibiChanged", true) &&
-      (have($item`ChibiBuddy™ (on)`) || have($item`ChibiBuddy™ (off)`)),
+    ready: () => have($item`ChibiBuddy™ (on)`) || have($item`ChibiBuddy™ (off)`),
     completed: () => get("_chibiChanged", true),
-    do: chibiSetup,
+    do: () => cliExecute("chibi chat"),
     limit: { soft: 1 },
   },
   {

--- a/src/tasks/daily.ts
+++ b/src/tasks/daily.ts
@@ -399,7 +399,7 @@ export const DailyTasks: Task[] = [
   {
     name: "Chibi Buddy",
     ready: () =>
-      get("_chibiChanged", true) &&
+      !get("_chibiChanged", true) &&
       (have($item`ChibiBuddy™ (on)`) || have($item`ChibiBuddy™ (off)`)),
     completed: () => get("_chibiChanged", true),
     do: chibiSetup,

--- a/src/tasks/daily.ts
+++ b/src/tasks/daily.ts
@@ -403,6 +403,7 @@ export const DailyTasks: Task[] = [
     ready: () => have($item`ChibiBuddy™ (on)`) || have($item`ChibiBuddy™ (off)`),
     completed: () => have($effect`ChibiChanged™`),
     do: () => chibiSetup(),
+    limit: { soft: 1 },
   },
   {
     name: "Refresh Latte",

--- a/src/tasks/daily.ts
+++ b/src/tasks/daily.ts
@@ -402,7 +402,7 @@ export const DailyTasks: Task[] = [
     name: "Chibi Buddy",
     ready: () => have($item`ChibiBuddy™ (on)`) || have($item`ChibiBuddy™ (off)`),
     completed: () => have($effect`ChibiChanged™`),
-    do: () => chibiSetup(),
+    do: chibiSetup,
     limit: { soft: 1 },
   },
   {
@@ -435,13 +435,13 @@ export const DailyTasks: Task[] = [
     name: "Configure I Voted! Sticker",
     ready: () => true,
     completed: () => have($item`"I Voted!" sticker`),
-    do: () => voterSetup(),
+    do: voterSetup,
   },
   {
     name: "Configure Pantogram",
     ready: () => Pantogram.have(),
     completed: () => Pantogram.havePants(),
-    do: () => pantogram(),
+    do: pantogram,
   },
   {
     name: "Configure Fourth of May Cosplay Saber",
@@ -604,7 +604,7 @@ export const DailyTasks: Task[] = [
       (get("neverendingPartyAlways") || get("_neverendingPartyToday")) &&
       get("_questPartyFair") === "unstarted",
     completed: () => get("_questPartyFair") !== "unstarted",
-    do: () => nepQuest(),
+    do: nepQuest,
     outfit: () =>
       myInebriety() > inebrietyLimit() &&
       have($item`Drunkula's wineglass`) &&
@@ -616,13 +616,13 @@ export const DailyTasks: Task[] = [
     name: "Check Barf Mountain Quest",
     ready: () => get("stenchAirportAlways") || get("_stenchAirportToday"),
     completed: () => !attemptCompletingBarfQuest,
-    do: () => checkBarfQuest(),
+    do: checkBarfQuest,
   },
   {
     name: "Configure Snojo",
     ready: () => get("snojoAvailable") && get("_snojoFreeFights") < 10,
     completed: () => snojoConfigured,
-    do: () => configureSnojo(),
+    do: configureSnojo,
   },
   // Final tasks
   {

--- a/src/tasks/daily.ts
+++ b/src/tasks/daily.ts
@@ -166,8 +166,8 @@ function voterSetup(): void {
   visitUrl(`choice.php?option=1&whichchoice=1331&g=${monsterVote}&local[]=${init}&local[]=${init}`);
 }
 
-function chibiBuffAvailable(): boolean {
-  if (!have($item`ChibiBuddy™ (on)`) && !have($item`ChibiBuddy™ (off)`)) return false;
+function chibiSetup(): void {
+  if (!have($item`ChibiBuddy™ (on)`) && !have($item`ChibiBuddy™ (off)`)) return;
   // We need to name our buddy when we turn it on!
   const chibiNames = [
     "SSBBHax",
@@ -183,7 +183,10 @@ function chibiBuffAvailable(): boolean {
     directlyUse($item`ChibiBuddy™ (on)`);
     if (handlingChoice()) {
       // This is the choice option for chibi chat
-      if (availableChoiceOptions()[5]) return true;
+      if (availableChoiceOptions()[5]) {
+        runChoice(5);
+        return;
+      }
       // Exit the choice, if our buddy died, this will give us back a buddy (off)
       runChoice(7);
     }
@@ -201,11 +204,13 @@ function chibiBuffAvailable(): boolean {
     }
     // We should now have our fresh buddy
     if (handlingChoice()) {
-      if (availableChoiceOptions()[5]) return true;
+      if (availableChoiceOptions()[5]) {
+        runChoice(5);
+        return;
+      }
       runChoice(7);
     }
   }
-  return false;
 }
 
 function pantogram(): void {
@@ -395,16 +400,9 @@ export function configureSnojo(): void {
 export const DailyTasks: Task[] = [
   {
     name: "Chibi Buddy",
-    ready: () => chibiBuffAvailable(),
+    ready: () => have($item`ChibiBuddy™ (on)`) || have($item`ChibiBuddy™ (off)`),
     completed: () => have($effect`ChibiChanged™`),
-    do: (): void => {
-      directlyUse($item`ChibiBuddy™ (on)`);
-      if (handlingChoice()) {
-        // Chibi chat
-        runChoice(5);
-        runChoice(7);
-      }
-    },
+    do: () => chibiSetup(),
   },
   {
     name: "Refresh Latte",


### PR DESCRIPTION
This just picks up the ChibiChanged buff (5 fam weight) during our daily tasks if it's available.

It does not do any caretaking of the Chibibuddy, so it'll only last a few days, but even if it just died it still gives you 5 turns of the buff.

There isn't any mafia support of chibibuddy currently, so this probably isn't very performant. It's been working good for me during eternal aftercore though.

Thanks to phred for the names ([Discord post](https://discord.com/channels/466605739838930955/864070665615179786/1042932371902693476)) but if it's too "cute" we can use some generic name? Or possibly just use the auto-generated name with an empty field.

This won't pick up the buff if you already had it from manually doing it pre-rollover, but I couldn't come up with a better `completed:` without mafia support