### PR TITLE
2 small fixes to Yachtzee! familiar weight calcs

### DIFF
--- a/src/yachtzee/familiar.ts
+++ b/src/yachtzee/familiar.ts
@@ -1,14 +1,12 @@
 import {
-  equippedItem,
   Familiar,
   familiarWeight,
   Item,
-  myFamiliar,
   numericModifier,
   print,
   weightAdjustment,
 } from "kolmafia";
-import { $effect, $familiar, $item, $slot, findLeprechaunMultiplier, have } from "libram";
+import { $effect, $familiar, $item, findLeprechaunMultiplier, have } from "libram";
 import { familiarWaterBreathingEquipment } from "../outfit";
 
 function bestFamUnderwaterGear(fam: Familiar): Item {

--- a/src/yachtzee/familiar.ts
+++ b/src/yachtzee/familiar.ts
@@ -24,11 +24,6 @@ function bestFamUnderwaterGear(fam: Familiar): Item {
 
 export function bestYachtzeeFamiliar(): Familiar {
   const haveUnderwaterFamEquipment = familiarWaterBreathingEquipment.some((item) => have(item));
-  const famWt =
-    familiarWeight(myFamiliar()) +
-    weightAdjustment() -
-    numericModifier(equippedItem($slot`familiar`), "Familiar Weight");
-
   const sortedUnderwaterFamiliars = Familiar.all()
     .filter(
       (fam) =>
@@ -40,14 +35,14 @@ export function bestYachtzeeFamiliar(): Familiar {
     )
     .sort(
       (left, right) =>
-        numericModifier(right, "Meat Drop", famWt, bestFamUnderwaterGear(right)) -
-        numericModifier(left, "Meat Drop", famWt, bestFamUnderwaterGear(left))
+        numericModifier(right, "Meat Drop", familiarWeight(right) + weightAdjustment(), bestFamUnderwaterGear(right)) -
+        numericModifier(left, "Meat Drop", familiarWeight(left) + weightAdjustment(), bestFamUnderwaterGear(left))
     );
 
   print(`Familiar bonus meat%:`, "blue");
   sortedUnderwaterFamiliars.forEach((fam) => {
     print(
-      `${fam} (${numericModifier(fam, "Meat Drop", famWt, bestFamUnderwaterGear(fam)).toFixed(
+      `${fam} (${numericModifier(fam, "Meat Drop", familiarWeight(fam) + weightAdjustment(), bestFamUnderwaterGear(fam)).toFixed(
         2
       )}%)`,
       "blue"

--- a/src/yachtzee/familiar.ts
+++ b/src/yachtzee/familiar.ts
@@ -21,6 +21,12 @@ function bestFamUnderwaterGear(fam: Familiar): Item {
     : $item`little bitty bathysphere`;
 }
 
+function getBuffedFamiliarWeight(fam: Familiar): number {
+  // returns the buffed weight of the given familiar. Doesn't count any equipment on the given familiar.
+  const weight = familiarWeight(fam) + weightAdjustment() - numericModifier(equippedItem($slot`familiar`), "Familiar Weight");
+  return fam.feasted ? weight + 10 : weight;
+}
+
 export function bestYachtzeeFamiliar(): Familiar {
   const haveUnderwaterFamEquipment = familiarWaterBreathingEquipment.some((item) => have(item));
   const sortedUnderwaterFamiliars = Familiar.all()
@@ -34,14 +40,14 @@ export function bestYachtzeeFamiliar(): Familiar {
     )
     .sort(
       (left, right) =>
-        numericModifier(right, "Meat Drop", familiarWeight(right) + weightAdjustment() - numericModifier(equippedItem($slot`familiar`), "Familiar Weight"), bestFamUnderwaterGear(right)) -
-        numericModifier(left, "Meat Drop", familiarWeight(left) + weightAdjustment() - numericModifier(equippedItem($slot`familiar`), "Familiar Weight"), bestFamUnderwaterGear(left))
+        numericModifier(right, "Meat Drop", getBuffedFamiliarWeight(right), bestFamUnderwaterGear(right)) -
+        numericModifier(left, "Meat Drop", getBuffedFamiliarWeight(left), bestFamUnderwaterGear(left))
     );
 
   print(`Familiar bonus meat%:`, "blue");
   sortedUnderwaterFamiliars.forEach((fam) => {
     print(
-      `${fam} (${numericModifier(fam, "Meat Drop", familiarWeight(fam) + weightAdjustment() - numericModifier(equippedItem($slot`familiar`), "Familiar Weight"), bestFamUnderwaterGear(fam)).toFixed(
+      `${fam} (${numericModifier(fam, "Meat Drop", getBuffedFamiliarWeight(fam), bestFamUnderwaterGear(fam)).toFixed(
         2
       )}%)`,
       "blue"

--- a/src/yachtzee/familiar.ts
+++ b/src/yachtzee/familiar.ts
@@ -23,7 +23,10 @@ function bestFamUnderwaterGear(fam: Familiar): Item {
 
 function getBuffedFamiliarWeight(fam: Familiar): number {
   // returns the buffed weight of the given familiar. Doesn't count any equipment on the given familiar.
-  const weight = familiarWeight(fam) + weightAdjustment() - numericModifier(equippedItem($slot`familiar`), "Familiar Weight");
+  const weight =
+    familiarWeight(fam) +
+    weightAdjustment() -
+    numericModifier(equippedItem($slot`familiar`), "Familiar Weight");
   return fam.feasted ? weight + 10 : weight;
 }
 
@@ -40,16 +43,29 @@ export function bestYachtzeeFamiliar(): Familiar {
     )
     .sort(
       (left, right) =>
-        numericModifier(right, "Meat Drop", getBuffedFamiliarWeight(right), bestFamUnderwaterGear(right)) -
-        numericModifier(left, "Meat Drop", getBuffedFamiliarWeight(left), bestFamUnderwaterGear(left))
+        numericModifier(
+          right,
+          "Meat Drop",
+          getBuffedFamiliarWeight(right),
+          bestFamUnderwaterGear(right)
+        ) -
+        numericModifier(
+          left,
+          "Meat Drop",
+          getBuffedFamiliarWeight(left),
+          bestFamUnderwaterGear(left)
+        )
     );
 
   print(`Familiar bonus meat%:`, "blue");
   sortedUnderwaterFamiliars.forEach((fam) => {
     print(
-      `${fam} (${numericModifier(fam, "Meat Drop", getBuffedFamiliarWeight(fam), bestFamUnderwaterGear(fam)).toFixed(
-        2
-      )}%)`,
+      `${fam} (${numericModifier(
+        fam,
+        "Meat Drop",
+        getBuffedFamiliarWeight(fam),
+        bestFamUnderwaterGear(fam)
+      ).toFixed(2)}%)`,
       "blue"
     );
   });

--- a/src/yachtzee/familiar.ts
+++ b/src/yachtzee/familiar.ts
@@ -1,4 +1,5 @@
 import {
+  equippedItem,
   Familiar,
   familiarWeight,
   Item,
@@ -6,7 +7,7 @@ import {
   print,
   weightAdjustment,
 } from "kolmafia";
-import { $effect, $familiar, $item, findLeprechaunMultiplier, have } from "libram";
+import { $effect, $familiar, $item, $slot, findLeprechaunMultiplier, have } from "libram";
 import { familiarWaterBreathingEquipment } from "../outfit";
 
 function bestFamUnderwaterGear(fam: Familiar): Item {
@@ -33,14 +34,14 @@ export function bestYachtzeeFamiliar(): Familiar {
     )
     .sort(
       (left, right) =>
-        numericModifier(right, "Meat Drop", familiarWeight(right) + weightAdjustment(), bestFamUnderwaterGear(right)) -
-        numericModifier(left, "Meat Drop", familiarWeight(left) + weightAdjustment(), bestFamUnderwaterGear(left))
+        numericModifier(right, "Meat Drop", familiarWeight(right) + weightAdjustment() - numericModifier(equippedItem($slot`familiar`), "Familiar Weight"), bestFamUnderwaterGear(right)) -
+        numericModifier(left, "Meat Drop", familiarWeight(left) + weightAdjustment() - numericModifier(equippedItem($slot`familiar`), "Familiar Weight"), bestFamUnderwaterGear(left))
     );
 
   print(`Familiar bonus meat%:`, "blue");
   sortedUnderwaterFamiliars.forEach((fam) => {
     print(
-      `${fam} (${numericModifier(fam, "Meat Drop", familiarWeight(fam) + weightAdjustment(), bestFamUnderwaterGear(fam)).toFixed(
+      `${fam} (${numericModifier(fam, "Meat Drop", familiarWeight(fam) + weightAdjustment() - numericModifier(equippedItem($slot`familiar`), "Familiar Weight"), bestFamUnderwaterGear(fam)).toFixed(
         2
       )}%)`,
       "blue"


### PR DESCRIPTION
I was poking around this code the other day and noticed a couple of minor issues.

Firstly the `famWt` calculation was using the currently equipped familiars weight rather than the familiars being checked.
Secondly the 3rd parameter being passed to `numericModifier()` is, according to the mafia wiki should be the buffed weight, excluding equipment as equipment is provided as the 4th parameter (see https://wiki.kolmafia.us/index.php/Numeric_modifier ).

I've tested this on subsequent days coming out of Normal Standard runs & immediately running garbo after breaking prism & emptying hagnks.

Before
```
> Familiar bonus meat%:
> Urchin Urchin (569.68%)
> Hobo Monkey (562.56%)
> Cat Burglar (467.83%)
> Leprechaun (467.83%)
> Jitterbug (467.83%)
> Casagnova Gnome (467.83%)
> Hunchbacked Minion (467.83%)
> Wild Hare (467.83%)
> Mutant Cactus Bud (467.83%)
> Cymbal-Playing Monkey (467.83%)
> Dancing Frog (467.83%)
> Chauvinist Pig (467.83%)
> Hippo Ballerina (467.83%)
> Knob Goblin Organ Grinder (467.83%)
> Piano Cat (467.83%)
> Dramatic Hedgehog (467.83%)
> Bloovian Groose (467.83%)
> Blavious Kloop (467.83%)
> Angry Jung Man (467.83%)
> Unconscious Collective (467.83%)
> Grimstone Golem (467.83%)
> Grim Brother (467.83%)
> Golden Monkey (467.83%)
> Adventurous Spelunker (467.83%)
> Cornbeefadon (467.83%)
> He-Boulder (467.83%)
> Best Familiar: Urchin Urchin
```
After
```
> Familiar bonus meat%:
> Urchin Urchin (556.79%)
> Hobo Monkey (553.00%)
> Angry Jung Man (480.87%)
> Cornbeefadon (454.75%)
> Grimstone Golem (436.34%)
> Grim Brother (433.70%)
> Hunchbacked Minion (433.70%)
> Cat Burglar (431.06%)
> Leprechaun (431.06%)
> Dancing Frog (431.06%)
> Chauvinist Pig (431.06%)
> Hippo Ballerina (431.06%)
> Knob Goblin Organ Grinder (431.06%)
> Piano Cat (431.06%)
> Dramatic Hedgehog (431.06%)
> Bloovian Groose (431.06%)
> Blavious Kloop (431.06%)
> Casagnova Gnome (431.06%)
> Unconscious Collective (431.06%)
> Jitterbug (431.06%)
> Wild Hare (431.06%)
> Golden Monkey (431.06%)
> Adventurous Spelunker (431.06%)
> Cymbal-Playing Monkey (431.06%)
> He-Boulder (431.06%)
> Mutant Cactus Bud (366.40%)
> Best Familiar: Urchin Urchin
```
So not a massive difference in this case but the calc being "correct" means there may be cases where the Hobo Monkey wins for some people over the Urchin Urchin and should allow the Mutant Cactus Bud to be used more often in situations where it is genuinely better than either of those due to the difference in experience on all 3 familiars.
You can see how the Angry Jung Man is now 3rd in the list as garbo has run it during free fights before attempting Yachtzee! so it has gained experience (and has the instant level 10 from the Short Order cook) compared to many of the others.
The Cornbeefadon is also getting a bump to 4th because of gaining the Short Order cook experience from simply being taken out to acquire the amulet coin. Thus a further improvement may be to take all meat drop familiars out at least once if the user owns the Short Order cook so they all get the free experience.