### PR TITLE
Change pizza and calzone of legend into regular diet options & don't prevent pilsners and pizza until ascending

### DIFF
--- a/src/diet.ts
+++ b/src/diet.ts
@@ -84,6 +84,7 @@ import { Potion, PotionTier } from "./potions";
 import { garboValue } from "./session";
 import synthesize from "./synthesis";
 import { estimatedGarboTurns } from "./turns";
+import { BooleanProperty } from "libram/dist/propertyTypes";
 
 const MPA = get("valueOfAdventure");
 print(`Using adventure value ${MPA}.`, HIGHLIGHT);
@@ -333,6 +334,13 @@ function menu(): MenuItem<Note>[] {
     (item) => new MenuItem<Note>(item, { maximum: availableAmount(item) })
   );
 
+  const legendaryPizzas = [
+    { pizza: $item`Pizza of Legend`, pref: "pizzaOfLegendEaten" },
+    { pizza: $item`Calzone of Legend`, pref: "calzoneOfLegendEaten" },
+  ]
+    .filter(({ pref }) => !get(pref))
+    .map(({ pizza }) => new MenuItem(pizza));
+
   return [
     // FOOD
     new MenuItem($item`Dreadsylvanian cold pocket`),
@@ -348,6 +356,7 @@ function menu(): MenuItem<Note>[] {
     new MenuItem(mallMin(lasagnas)),
     new MenuItem(mallMin(smallEpics)),
     new MenuItem($item`green hamhock`),
+    ...legendaryPizzas,
 
     // BOOZE
     new MenuItem($item`elemental caipiroska`),
@@ -589,9 +598,8 @@ export function potionMenu(
     ? potion($item`Boris's bread`, { price: 2 * ingredientCost($item`Yeast of Boris`) })
     : [];
 
-  // Replace string with BooleanProperty later
-  const ofLegendPotion = (item: Item, prefName: string) => {
-    if (get(prefName, true)) return [];
+  const ofLegendPotion = (item: Item, pref: BooleanProperty) => {
+    if (get(pref)) return [];
 
     const recipes = [
       item,
@@ -606,12 +614,6 @@ export function potionMenu(
         sum($items`Vegetable of Jarlsberg, St. Sneaky Pete's Whey, Yeast of Boris`, ingredientCost),
     });
   };
-
-  const ofLegendMenuItems = [
-    ...ofLegendPotion($item`Calzone of Legend`, "calzoneOfLegendEaten"),
-    ...ofLegendPotion($item`Pizza of Legend`, "pizzaOfLegendEaten"),
-    ...ofLegendPotion($item`Deep Dish of Legend`, "deepDishOfLegendEaten"),
-  ];
 
   return [
     ...baseMenu,
@@ -629,7 +631,7 @@ export function potionMenu(
     ...campfireHotdog,
     ...foodCone,
     ...borisBread,
-    ...ofLegendMenuItems,
+    ...ofLegendPotion($item`Deep Dish of Legend`, "deepDishOfLegendEaten"),
 
     // BOOZE POTIONS
     ...potion($item`dirt julep`),

--- a/src/diet.ts
+++ b/src/diet.ts
@@ -287,7 +287,7 @@ const stomachLiverCleaners = new Map([
   [$item`designer sweatpants`, [0, -1]],
 ]);
 
-function canCookPizza(pizza: Item): boolean {
+function canCookLegendaryPizza(pizza: Item): boolean {
   const recipes = [
     pizza,
     ...$items`roasted vegetable of Jarlsberg, Pete's rich ricotta, Boris's bread`,
@@ -348,7 +348,7 @@ function menu(): MenuItem<Note>[] {
   ]
     .filter(({ pizza, pref }) => {
       if (get(pref)) return false;
-      return canCookPizza(pizza);
+      return canCookLegendaryPizza(pizza);
     })
     .map(({ pizza }) => new MenuItem(pizza));
 
@@ -611,7 +611,7 @@ export function potionMenu(
 
   const deepDish = get("deepDishOfLegendEaten")
     ? []
-    : !canCookPizza($item`Deep Dish of Legend`)
+    : !canCookLegendaryPizza($item`Deep Dish of Legend`)
     ? []
     : limitedPotion($item`Deep Dish of Legend`, 1, {
         price:

--- a/src/diet.ts
+++ b/src/diet.ts
@@ -287,18 +287,17 @@ const stomachLiverCleaners = new Map([
   [$item`designer sweatpants`, [0, -1]],
 ]);
 
-function canCookLegendaryPizza(pizza: Item): boolean {
-  const recipes = [
-    pizza,
-    ...$items`roasted vegetable of Jarlsberg, Pete's rich ricotta, Boris's bread`,
-  ].map((i) => toInt(i));
-  return !recipes.some((id) => get(`unknownRecipe${id}`, true));
-}
-
 function legendaryPizzaToMenu(
   pizzas: { item: Item; pref: string }[],
   maker: (out: { item: Item; price: number }) => MenuItem<Note>
 ) {
+  const canCookLegendaryPizza = (pizza: Item): boolean => {
+    const recipes = [
+      pizza,
+      ...$items`roasted vegetable of Jarlsberg, Pete's rich ricotta, Boris's bread`,
+    ].map((i) => toInt(i));
+    return !recipes.some((id) => get(`unknownRecipe${id}`, true));
+  };
   return pizzas
     .filter(({ item, pref }) => !get(pref, true) && canCookLegendaryPizza(item))
     .map(({ item }) =>

--- a/src/diet.ts
+++ b/src/diet.ts
@@ -347,7 +347,7 @@ function menu(): MenuItem<Note>[] {
     { pizza: $item`Calzone of Legend`, pref: "calzoneOfLegendEaten" },
   ]
     .filter(({ pizza, pref }) => {
-      if (!get(pref)) return false;
+      if (get(pref)) return false;
       return canCookPizza(pizza);
     })
     .map(({ pizza }) => new MenuItem(pizza));

--- a/src/diet.ts
+++ b/src/diet.ts
@@ -297,14 +297,13 @@ function canCookLegendaryPizza(pizza: Item): boolean {
 
 function legendaryPizzaToMenu(
   pizzas: { item: Item; pref: string }[],
-  maker: (out: { item: Item; limit: number; price: number }) => MenuItem<Note>
+  maker: (out: { item: Item; price: number }) => MenuItem<Note>
 ) {
   return pizzas
     .filter(({ item, pref }) => !get(pref, true) && canCookLegendaryPizza(item))
     .map(({ item }) =>
       maker({
         item,
-        limit: 1,
         price:
           2 *
           sum(
@@ -628,8 +627,7 @@ export function potionMenu(
 
   const deepDish = legendaryPizzaToMenu(
     [{ item: $item`Deep Dish of Legend`, pref: "deepDishOfLegendEaten" }],
-    (out: { item: Item; limit: number; price: number }) =>
-      limitedPotion(out.item, 1, { price: out.price })[0]
+    (out: { item: Item; price: number }) => limitedPotion(out.item, 1, { price: out.price })[0]
   );
 
   return [

--- a/src/diet.ts
+++ b/src/diet.ts
@@ -289,7 +289,7 @@ const stomachLiverCleaners = new Map([
 
 function legendaryPizzaToMenu(
   pizzas: { item: Item; pref: string }[],
-  maker: (out: { item: Item; price: number }) => MenuItem<Note>
+  maker: (out: { item: Item; price: number }) => MenuItem<Note> | MenuItem<Note>[]
 ) {
   const canCookLegendaryPizza = (pizza: Item): boolean => {
     const recipes = [
@@ -364,7 +364,7 @@ function menu(): MenuItem<Note>[] {
       { item: $item`Calzone of Legend`, pref: "calzoneOfLegendEaten" },
       { item: $item`Pizza of Legend`, pref: "pizzaOfLegendEaten" },
     ],
-    (out) => new MenuItem<Note>(out.item, { priceOverride: out.price })
+    (out) => new MenuItem<Note>(out.item, { maximum: 1, priceOverride: out.price })
   );
 
   return [
@@ -382,7 +382,7 @@ function menu(): MenuItem<Note>[] {
     new MenuItem(mallMin(lasagnas)),
     new MenuItem(mallMin(smallEpics)),
     new MenuItem($item`green hamhock`),
-    ...legendaryPizzas,
+    ...legendaryPizzas.flat(),
 
     // BOOZE
     new MenuItem($item`elemental caipiroska`),
@@ -626,7 +626,7 @@ export function potionMenu(
 
   const deepDish = legendaryPizzaToMenu(
     [{ item: $item`Deep Dish of Legend`, pref: "deepDishOfLegendEaten" }],
-    (out: { item: Item; price: number }) => limitedPotion(out.item, 1, { price: out.price })[0]
+    (out: { item: Item; price: number }) => limitedPotion(out.item, 1, { price: out.price })
   );
 
   return [
@@ -645,7 +645,7 @@ export function potionMenu(
     ...campfireHotdog,
     ...foodCone,
     ...borisBread,
-    ...deepDish,
+    ...deepDish.flat(),
 
     // BOOZE POTIONS
     ...potion($item`dirt julep`),

--- a/src/diet.ts
+++ b/src/diet.ts
@@ -292,8 +292,7 @@ function canCookLegendaryPizza(pizza: Item): boolean {
     pizza,
     ...$items`roasted vegetable of Jarlsberg, Pete's rich ricotta, Boris's bread`,
   ].map((i) => toInt(i));
-  if (recipes.some((id) => get(`unknownRecipe${id}`, true))) return false;
-  return true;
+  return !recipes.some((id) => get(`unknownRecipe${id}`));
 }
 
 export const mallMin: (items: Item[]) => Item = (items: Item[]) => maxBy(items, mallPrice, true);

--- a/src/diet.ts
+++ b/src/diet.ts
@@ -328,7 +328,7 @@ function menu(): MenuItem<Note>[] {
   const boxingDayCareItems = $items`glass of raw eggs, punch-drunk punch`.filter((item) =>
     have(item)
   );
-  const pilsners = $items`astral pilsner`.filter((item) => globalOptions.ascend && have(item));
+  const pilsners = $items`astral pilsner`.filter((item) => have(item));
   const limitedItems = [...boxingDayCareItems, ...pilsners].map(
     (item) => new MenuItem<Note>(item, { maximum: availableAmount(item) })
   );
@@ -607,13 +607,11 @@ export function potionMenu(
     });
   };
 
-  const ofLegendMenuItems = globalOptions.ascend
-    ? [
-        ...ofLegendPotion($item`Calzone of Legend`, "calzoneOfLegendEaten"),
-        ...ofLegendPotion($item`Pizza of Legend`, "pizzaOfLegendEaten"),
-        ...ofLegendPotion($item`Deep Dish of Legend`, "deepDishOfLegendEaten"),
-      ]
-    : [];
+  const ofLegendMenuItems = [
+    ...ofLegendPotion($item`Calzone of Legend`, "calzoneOfLegendEaten"),
+    ...ofLegendPotion($item`Pizza of Legend`, "pizzaOfLegendEaten"),
+    ...ofLegendPotion($item`Deep Dish of Legend`, "deepDishOfLegendEaten"),
+  ];
 
   return [
     ...baseMenu,

--- a/src/diet.ts
+++ b/src/diet.ts
@@ -292,7 +292,7 @@ function canCookLegendaryPizza(pizza: Item): boolean {
     pizza,
     ...$items`roasted vegetable of Jarlsberg, Pete's rich ricotta, Boris's bread`,
   ].map((i) => toInt(i));
-  return !recipes.some((id) => get(`unknownRecipe${id}`));
+  return !recipes.some((id) => get(`unknownRecipe${id}`, true));
 }
 
 export const mallMin: (items: Item[]) => Item = (items: Item[]) => maxBy(items, mallPrice, true);

--- a/src/yachtzee/diet.ts
+++ b/src/yachtzee/diet.ts
@@ -508,16 +508,17 @@ export function yachtzeeChainDiet(simOnly?: boolean): boolean {
         );
   const reservedFullness =
     2 * toInt(!get("deepDishOfLegendEaten")) + // to be consumed in yachtzee
-    2 * toInt(!get("calzoneOfLegendEaten") && globalOptions.ascend) + // to be consumed post-yachtzee
-    2 * toInt(!get("pizzaOfLegendEaten") && globalOptions.ascend) + // to be consumed post-yachtzee
+    2 * toInt(!get("calzoneOfLegendEaten")) + // to be consumed post-yachtzee
+    2 * toInt(!get("pizzaOfLegendEaten")) + // to be consumed post-yachtzee
     2; // subtract 2 for Boris Bread and Jumping Horseradish
   const fullnessAvailable =
     myLevel() >= 13
       ? Math.max(0, fullnessLimit() - myFullness() + toInt(haveDistentionPill) - reservedFullness)
       : 0;
-  const reservedInebriety = globalOptions.ascend
-    ? Math.max(0, itemAmount($item`astral pilsner`) - toInt(get("_mimeArmyShotglassUsed")))
-    : 0;
+  const reservedInebriety = Math.max(
+    0,
+    itemAmount($item`astral pilsner`) - toInt(get("_mimeArmyShotglassUsed"))
+  );
   const inebrietyAvailable =
     myLevel() >= 13
       ? Math.max(
@@ -682,7 +683,6 @@ export function yachtzeeChainDiet(simOnly?: boolean): boolean {
     yachtzeePotionProfits(new Potion($item`Deep Dish of Legend`), yachtzeeTurns) +
     pizzaAdditionalAdvPerFullness * 2 * VOA;
   const deepDishPizzas =
-    globalOptions.ascend &&
     !get("deepDishOfLegendEaten") &&
     deepDishValue > retrievePrice($item`Deep Dish of Legend`) &&
     !get("unknownRecipe11000") &&


### PR DESCRIPTION
Benefits: generally it's better to consume these items immediately coming out of an ascension rather than at a later date.

Drawbacks: users whose preferences are out of sync will try and fail to eat the pizzas resulting in at least one incorrect diet calculation.