### PR TITLE
Categorically ban cheap sunglasses from embezzler outfit

### DIFF
--- a/src/outfit/embezzler.ts
+++ b/src/outfit/embezzler.ts
@@ -24,6 +24,7 @@ export function embezzlerOutfit(spec: OutfitSpec = {}, target = $location.none):
   );
 
   outfit.modifier.push(`${valueOfMeat(BonusEquipMode.EMBEZZLER)} Meat Drop`, "-tie");
+  outfit.avoid.push($item`cheap sunglasses`); // Even if we're adventuring in Barf Mountain itself, these are bad
   outfit.familiar ??= meatFamiliar();
 
   const bjornChoice = chooseBjorn(BonusEquipMode.EMBEZZLER, outfit.familiar);


### PR DESCRIPTION
setLocation alone won't work here. We should consider adding location ID or name to the key we use for outfit caching in libram.