### PR TITLE
Greedy dog for diet

### DIFF
--- a/src/diet.ts
+++ b/src/diet.ts
@@ -660,6 +660,7 @@ export function potionMenu(
     ...potion($item`Feliz Navidad`),
     ...potion($item`broberry brogurt`),
     ...potion($item`haunted martini`),
+    ...potion($item`bottle of Greedy Dog`),
     ...potion($item`twice-haunted screwdriver`, { price: twiceHauntedPrice }),
     ...limitedPotion($item`high-end ginger wine`, availableAmount($item`high-end ginger wine`)),
     ...limitedPotion($item`Hot Socks`, hasSpeakeasy ? 3 : 0, { price: 5000 }),

--- a/src/yachtzee/diet.ts
+++ b/src/yachtzee/diet.ts
@@ -142,6 +142,10 @@ class YachtzeeDietUtils {
         ensureConsumable("Boris's bread", n, 1, 0, 0);
         eat(n, $item`Boris's bread`);
       }),
+      new YachtzeeDietEntry("bottle of Greedy Dog", 0, 0, 3, 0, (n: number) => {
+        ensureConsumable("bottle of Greedy Dog", n, 0, 3, 0);
+        eat(n, $item`bottle of Greedy Dog`);
+      }),
       new YachtzeeDietEntry("clara's bell", 0, 0, 0, 0, () => {
         use($item`Clara's bell`);
         globalOptions.clarasBellClaimed = true;
@@ -672,6 +676,12 @@ export function yachtzeeChainDiet(simOnly?: boolean): boolean {
       fullnessLimit() + toInt(haveDistentionPill)
       ? 1
       : 0;
+  const greedyDogs =
+    mallPrice($item`bottle of Greedy Dog`) <= 60000 &&
+    haveEffect($effect`Covetin' Drunk`) < yachtzeeTurns &&
+    myInebriety() + 3 + pickleJuiceToDrink * 5 <= inebrietyLimit()
+      ? 1
+      : 0;
   // Opportunistically fit in Deep Dish of Legend only if we have enough stomach space
   const pizzaAdditionalAdvPerFullness = 24 / 2 - 31.5 / 5;
   const deepDishValue =
@@ -711,7 +721,8 @@ export function yachtzeeChainDiet(simOnly?: boolean): boolean {
     yachtzeePotionSetup(yachtzeeTurns, true) +
     cologneToChew * ((yachtzeeTurns + 60 + 5 * toInt(havePYECCharge)) * 1000 - colognePrice) +
     (horseradishes > 0 ? yachtzeeTurns * 1000 : 0) +
-    (borisBreads > 0 ? yachtzeeTurns * 1000 : 0);
+    (borisBreads > 0 ? yachtzeeTurns * 1000 : 0) +
+    (greedyDogs > 0 ? yachtzeeTurns * 2000 : 0);
 
   // We assume that the embezzlers after yachtzee chaining would still benefit from our start-of-day buffs
   // so the assumption is that all the gregged embezzlies can be approximated as marginal KGEs with profits of 3 * VOA
@@ -764,6 +775,7 @@ export function yachtzeeChainDiet(simOnly?: boolean): boolean {
     ["beggin' cologne", cologneToChew],
     ["jumping horseradish", horseradishes],
     ["Boris's bread", borisBreads],
+    ["bottle of Greedy Dog", greedyDogs],
     ["Deep Dish of Legend", deepDishPizzas],
   ];
 
@@ -830,6 +842,7 @@ export function yachtzeeChainDiet(simOnly?: boolean): boolean {
   acquire(filters, $item`mojo filter`, 2 * mallPrice($item`mojo filter`));
   acquire(horseradishes, $item`jumping horseradish`, 60000);
   acquire(borisBreads, $item`Boris's bread`, 60000);
+  acquire(greedyDogs, $item`bottle of Greedy Dog`, 60000);
   acquire(deepDishPizzas, $item`Deep Dish of Legend`, 1.2 * deepDishValue);
 
   // Get fishy turns


### PR DESCRIPTION
This is simple to add for general garbo, but yachtzee is a bit more arcane for me. Hopefully I did it correctly, I just left the max price of them at 60k, same as boris bread and radishes

(Max price for embezzlers would be something under 40k, and something under 80k for yachtzee depending on user VoA)

I don't know if the supply of these can meet demand currently, but people might consider zapping race car reds and lambadas. So essentially people with the beer garden are making one per week if I understand that correctly.

Perhaps that was a reason these weren't implemented before though. to not mess with the supply of those.