### PR TITLE
fix: use my forks of Ezandora's scripts to fix modifier issues

### DIFF
--- a/mafia/dependencies.txt
+++ b/mafia/dependencies.txt
@@ -1,7 +1,7 @@
-github Ezandora/Bastille Release
-github Ezandora/Gain Release
 github Ezandora/Briefcase Release
 github Ezandora/Far-Future Release
 github Ezandora/Detective-Solver Release
 github Loathing-Associates-Scripting-Society/KoL-MineVolcano
 github Loathing-Associates-Scripting-Society/combo release
+github midgleyc/Bastille Release
+github midgleyc/Gain Release


### PR DESCRIPTION
Recent modifier changes in https://github.com/kolmafia/kolmafia/pull/1815 broke Bastille and Gain; point to my forks instead until the PRs are merged so that users don't have to pull scripts manually.