### PR TITLE
Update .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-yaml
       - id: check-merge-conflict
@@ -9,18 +9,18 @@ repos:
     hooks:
       - id: check-json5
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: "v8.24.0"
+    rev: "v8.45.0"
     hooks:
       - id: eslint
         additional_dependencies:
-          - eslint@7.32.0
-          - eslint-config-prettier@8.3.0
-          - eslint-plugin-libram@0.2.17
+          - eslint@^7.28.0
+          - eslint-config-prettier@^8.3.0
+          - eslint-plugin-libram@^0.2.32
         files: \.[jt]sx?$ # *.js, *.jsx, *.ts and *.tsx
         types: [file]
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v3.0.0-alpha.0"
+    rev: "v3.0.0"
     hooks:
       - id: prettier
         additional_dependencies:
-          - prettier@2.5.1
+          - prettier@^2.3.1


### PR DESCRIPTION
Fixed the eslint & prettier package versions to match package.json so it will lint the same, pre-commit had diverged so it was linting differently