### PR TITLE
Skip last fortune consult wait

### DIFF
--- a/packages/garbo/src/tasks/daily.ts
+++ b/packages/garbo/src/tasks/daily.ts
@@ -607,7 +607,7 @@ const DailyTasks: GarboTask[] = [
       Clan.with("Bonus Adventures from Hell", () =>
         cliExecute(`fortune ${getPlayerId("OnlyFax")}`),
       );
-      wait(10);
+      if (get("_clanFortuneConsultUses") < 3) wait(10);
     },
     limit: { skip: 3 },
     spendsTurn: false,


### PR DESCRIPTION
If the last fortune consult is successfully sent, we don't need to wait 10 seconds for anything.

So, save 10 seconds of waiting?