### PR TITLE
Just having a warbear LP-ROM burner isn't enough to record with it

### DIFF
--- a/packages/garbo/src/mood.ts
+++ b/packages/garbo/src/mood.ts
@@ -176,7 +176,7 @@ export function meatMood(
 
   const canRecord =
     getWorkshed() === $item`warbear LP-ROM burner` ||
-    (have($item`warbear LP-ROM burner`) && !get("_workshedItemUsed")) || 
+    (have($item`warbear LP-ROM burner`) && !get("_workshedItemUsed")) ||
     get("questG04Nemesis") === "finished";
 
   if (myClass() === $class`Accordion Thief` && myLevel() >= 15 && !canRecord) {


### PR DESCRIPTION
At least compared to before, we should check that our workshed item hasn't been swapped yet before saying we can record.

We could potentially extend this further into checking whether the workshed="??" setting has been set to something that's not burner. I'm not sure since setting that doesn't actually guarantee we'll change it, but what do y'all think?