### PR TITLE
Special handling for more eggnet donations

### DIFF
--- a/packages/garbo/src/tasks/freeEggDonation.ts
+++ b/packages/garbo/src/tasks/freeEggDonation.ts
@@ -1,14 +1,17 @@
 import {
+  Effect,
   equippedItem,
   haveEquipped,
   Item,
   itemType,
+  jumpChance,
   Monster,
   myBuffedstat,
   myDaycount,
   myId,
   myMaxhp,
   restoreHp,
+  restoreMp,
   toInt,
   useFamiliar,
   visitUrl,
@@ -31,13 +34,18 @@ import {
   ensureEffect,
   get,
   have,
+  MaximizeOptions,
   Requirement,
   RetroCape,
 } from "libram";
 import { Macro } from "../combat";
 import { GarboStrategy } from "../combatStrategy";
 import { globalOptions } from "../config";
-import { freeRunConstraints, tryFindFreeRunOrBanish } from "../lib";
+import {
+  freeRunConstraints,
+  safeRestoreMpTarget,
+  tryFindFreeRunOrBanish,
+} from "../lib";
 import { GarboTask } from "./engine";
 
 function queryEggNetIncomplete(): Map<Monster, number> {
@@ -97,12 +105,13 @@ function findDonateMonster(
           (onlyFree && !x.attributes.includes("FREE")),
       ),
     // Could have special handling
-    $monster`invader bullet`, // Instantly lose on third combat round
     $monster`mining grobold`, // 90% hp physical damage on first and every 2 rounds
-    $monster`swamp monster`, // 100% hp stench damage every round
-    $monster`regular thief`, // Lose 100 turns of an effect every round unless stunned
-    $monster`spooky ghost`, // 100% hp spooky damage every round
-    $monster`crypt creeper`, // 40-60% hp damage per round, cannot be reduced
+    // Lose 100 turns of an effect every round unless stunned, avoid without Shadow Noodles and 100% jump chance
+    ...$monsters`regular thief`.filter(
+      () =>
+        have($skill`Shadow Noodles`) &&
+        jumpChance($monster`regular thief`) >= 100,
+    ),
     // Impossible, cannot use items or skills
     ...$monsters`quadfaerie, cursed villager, plywood cultists, barrow wraith?, Source Agent`,
   ]);
@@ -134,12 +143,68 @@ function mimicEscape(): ActionSource | undefined {
 
 function shouldDelevel(monster: Monster): boolean {
   return (
-    monster.attributes.includes("Scale:") ||
-    myBuffedstat($stat`Moxie`) < monster.baseAttack + 10 ||
-    (have($skill`Hero of the Half-Shell`) &&
-      itemType(equippedItem($slot`offhand`)) === "shield" &&
-      myBuffedstat($stat`Muscle`) < monster.baseAttack + 10)
+    !$monsters`invader bullet, swamp monster, regular thief, spooky ghost`.includes(
+      monster,
+    ) &&
+    (monster.attributes.includes("Scale:") ||
+      myBuffedstat($stat`Moxie`) < monster.baseAttack + 10 ||
+      (have($skill`Hero of the Half-Shell`) &&
+        itemType(equippedItem($slot`offhand`)) === "shield" &&
+        myBuffedstat($stat`Muscle`) < monster.baseAttack + 10))
   );
+}
+
+function monsterRequirements(monster: Monster): Requirement {
+  const maximize = [
+    "-100 Thorns",
+    "-100 Sporadic Thorns",
+    "-100 Damage Aura",
+    "-100 Sporadic Damage Aura",
+  ];
+  const options: Partial<MaximizeOptions> = {
+    preventEquip: $items`carnivorous potted plant, Kramco Sausage-o-Matic™`,
+  };
+  switch (monster) {
+    case $monster`swamp monster`:
+      maximize.push("100 Stench Resistance");
+      break;
+    case $monster`spooky ghost`:
+      maximize.push("100 Spooky Resistance");
+      break;
+    default:
+      maximize.push("100 Avoid Attack");
+      options.bonusEquip = new Map<Item, number>([
+        [$item`unwrapped knock-off retro superhero cape`, 300],
+        [$item`navel ring of navel gazing`, 50],
+        [$item`ancient stone head`, 33],
+        [$item`asteroid belt`, 25],
+        [$item`attorney's badge`, 20],
+        [$item`propeller beanie`, 10],
+        [$item`Mayflower bouquet`, 6.5],
+      ]);
+      break;
+  }
+  return new Requirement(maximize, options);
+}
+
+function monsterEffects(monster: Monster): Effect[] {
+  const effects: Effect[] = [];
+  if ($monsters`swamp monster, spooky ghost`.includes(monster)) {
+    if (have($skill`Elemental Saucesphere`)) {
+      effects.push($effect`Elemental Saucesphere`);
+    }
+    if (have($skill`Astral Shell`)) {
+      effects.push($effect`Astral Shell`);
+    }
+  } else if (monster === $monster`regular thief`) {
+    if (have($skill`Springy Fusilli`)) {
+      effects.push($effect`Springy Fusilli`);
+    }
+    if (have($skill`Walberg's Dim Bulb`)) {
+      effects.push($effect`Walberg's Dim Bulb`);
+    }
+  }
+  return effects;
 }
 
 function mimicEggDonation(): GarboTask[] {
@@ -175,6 +240,10 @@ function mimicEggDonation(): GarboTask[] {
         () =>
           Macro.externalIf(shouldDelevel(donation.monster), Macro.delevel())
             .externalIf(
+              donation.monster === $monster`regular thief`,
+              Macro.trySkill($skill`Shadow Noodles`),
+            )
+            .externalIf(
               Math.min(100 - donation.count, 3 - get("_mimicEggsDonated")) > 0,
               Macro.trySkill($skill`%fn, lay an egg`),
             )
@@ -183,7 +252,8 @@ function mimicEggDonation(): GarboTask[] {
               Macro.trySkill($skill`%fn, lay an egg`),
             )
             .externalIf(
-              Math.min(100 - donation.count, 3 - get("_mimicEggsDonated")) > 2,
+              Math.min(100 - donation.count, 3 - get("_mimicEggsDonated")) >
+                2 && donation.monster !== $monster`invader bullet`,
               Macro.trySkill($skill`%fn, lay an egg`),
             )
             .externalIf(
@@ -195,35 +265,15 @@ function mimicEggDonation(): GarboTask[] {
       ),
       prepare: () => {
         useFamiliar($familiar`Chest Mimic`);
-        escape?.prepare(
-          new Requirement(
-            [
-              "100 Avoid Attack",
-              "-100 Thorns",
-              "-100 Sporadic Thorns",
-              "-100 Damage Aura",
-              "-100 Sporadic Damage Aura",
-            ],
-            {
-              bonusEquip: new Map<Item, number>([
-                [$item`unwrapped knock-off retro superhero cape`, 300],
-                [$item`navel ring of navel gazing`, 50],
-                [$item`ancient stone head`, 33],
-                [$item`asteroid belt`, 25],
-                [$item`attorney's badge`, 20],
-                [$item`propeller beanie`, 10],
-                [$item`Mayflower bouquet`, 6.5],
-              ]),
-              preventEquip: $items`carnivorous potted plant, Kramco Sausage-o-Matic™`,
-            },
-          ),
-        );
+        escape?.prepare(monsterRequirements(donation.monster));
         if (haveEquipped($item`unwrapped knock-off retro superhero cape`)) {
           RetroCape.set("heck", "hold");
         }
         if (have($skill`Blood Bubble`)) ensureEffect($effect`Blood Bubble`);
         restoreHp(myMaxhp());
+        restoreMp(safeRestoreMpTarget());
       },
+      effects: () => monsterEffects(donation.monster),
       limit: { skip: 1 },
       spendsTurn: false,
       sobriety: "sober",


### PR DESCRIPTION
I haven't tested this

* invader bullet: only allow 2 turns
* swamp monster: maximize stench resistance
* regular thief: only allowed with Shadow Noodles & 100% jump chance
* spooky ghost: maximize spooky resistance

Remove crypt creeper as it is finished