### PR TITLE
Exclude The Barracks from CookbookBat Quests as per #2565

### DIFF
--- a/packages/garbo-lib/src/wanderer/cookbookbatquest.ts
+++ b/packages/garbo-lib/src/wanderer/cookbookbatquest.ts
@@ -11,7 +11,7 @@ export function cookbookbatQuestFactory(
   const questReward = get("_cookbookbatQuestIngredient");
   const questMonster = get("_cookbookbatQuestMonster");
   // TODO: These are fixed in mafia (we get the correct location), however we cannot use peridot to target them for cookbookbat specifically, because we cannot know which monster cookbookbat wants because of duplicate names
-  const blackListedLocations = $locations`The Orcish Frat House, The Orcish Frat House (Bombed Back to the Stone Age), The Island Barracks`;
+  const blackListedLocations = $locations`The Orcish Frat House, The Orcish Frat House (Bombed Back to the Stone Age)`;
   if (
     ["yellow ray", "freefight", "freerun"].includes(type) && // Runs still get you the quest reward
     questLocation &&

--- a/packages/garbo-lib/src/wanderer/lib.ts
+++ b/packages/garbo-lib/src/wanderer/lib.ts
@@ -218,7 +218,7 @@ function canWanderTypeFreeFight(location: Location): boolean {
   );
 }
 
-const wandererSkiplist = $locations`The Smut Orc Logging Camp, The Batrat and Ratbat Burrow, Guano Junction, The Beanbat Chamber, A-Boo Peak, The Mouldering Mansion, The Rogue Windmill, The Stately Pleasure Dome, Pandamonium Slums, Lair of the Ninja Snowmen`;
+const wandererSkiplist = $locations`The Smut Orc Logging Camp, The Batrat and Ratbat Burrow, Guano Junction, The Beanbat Chamber, A-Boo Peak, The Mouldering Mansion, The Rogue Windmill, The Stately Pleasure Dome, Pandamonium Slums, Lair of the Ninja Snowmen, The Island Barracks`;
 function canWanderTypeWander(location: Location): boolean {
   return !wandererSkiplist.includes(location) && location.wanderers;
 }


### PR DESCRIPTION
[BUG] KoL erroneously gives cookbookbat quests in Island Barracks post AT nemesis boss defeat

Fixes #2565