### PR TITLE
don't try resonances in the mayam if we've already submitted a greedy combination

### DIFF
--- a/packages/garbo/src/resources/mayam.ts
+++ b/packages/garbo/src/resources/mayam.ts
@@ -71,9 +71,11 @@ function valueCombination(
 
 function getAvailableResonances(
   forbiddenSymbols: MayamCalendar.Glyph[],
+  indexCap: number,
 ): MayamCalendar.CombinationString[] {
   return MayamCalendar.RESONANCE_KEYS.filter(
-    (combination) =>
+    (combination, index) =>
+      index < indexCap &&
       !MayamCalendar.toCombination([combination]).some((sym) =>
         forbiddenSymbols.includes(sym),
       ),
@@ -117,18 +119,16 @@ function expandCombinationGroup<N extends number>(
     ...MayamCalendar.symbolsUsed(),
   ];
   return [
-    ...getAvailableResonances(forbiddenSymbols)
-      .filter((resonance) => {
-        const leftmostIndex = Math.min(...group.map(resonanceIndex));
-        return resonanceIndex(resonance) < leftmostIndex;
-      })
-      .map(
-        (resonance) =>
-          [...group, resonance] as [
-            ...Tuple<MayamCalendar.CombinationString, N>,
-            MayamCalendar.CombinationString,
-          ],
-      ),
+    ...getAvailableResonances(
+      forbiddenSymbols,
+      Math.min(...group.map(resonanceIndex)),
+    ).map(
+      (resonance) =>
+        [...group, resonance] as [
+          ...Tuple<MayamCalendar.CombinationString, N>,
+          MayamCalendar.CombinationString,
+        ],
+    ),
     [...group, getBestGreedyCombination(forbiddenSymbols)],
   ];
 }


### PR DESCRIPTION
In our mayam calendar code we (prior to this PR) only consider resonances to the "right" of the "rightmost" resonance in a combination, in order to avoid redundantly examining identical combinations. For example, if we look at RESONANCE_2, RESONANCE_1, GREEDY, we don't want to also consider RESONANCE_1, RESONANCE_2, GREEDY

But right now that setup works poorly when we have non-resonances in there, because `indexOf` returns -1 for values not present in the array.  This change will make it so that once a combination includes a greedy pick, we no longer consider resonances in it.