### PR TITLE
Add XO Skeleton & Mechanical Songbird to ConstantValueFamiliars

### DIFF
--- a/packages/garbo/src/familiar/constantValueFamiliars.ts
+++ b/packages/garbo/src/familiar/constantValueFamiliars.ts
@@ -149,7 +149,7 @@ const standardFamiliars: ConstantValueFamiliar[] = [
   },
   {
     familiar: $familiar`XO Skeleton`,
-    value: () => garboAverageValue(...$items`X, O`) / 18,
+    value: () => garboAverageValue(...$items`X, O`) / 9, // counters for X & O are simultaneous but offset by 5
   },
   {
     familiar: $familiar`Mechanical Songbird`,


### PR DESCRIPTION
ARE YOU HAPPY NOW ZASQ?


```
Executing Barf Turn/Barf
Choosing to use Mechanical Songbird (expected value of 2334.0 from familiar drops, 86.6 from familiar abilities and 2089.1 from outfit) over Robortender (expected value of 119.7 from familiar drops, 1293.7 from familiar abilities and 2006.6 from outfit).
```
<img width="476" height="32" alt="image" src="https://github.com/user-attachments/assets/06b93b03-ac15-4a5e-aa34-58fc400134ec" />
