### PR TITLE
fix: allow feeding robortender drinks from inventory

### DIFF
--- a/packages/garbo/src/tasks/dailyFamiliars.ts
+++ b/packages/garbo/src/tasks/dailyFamiliars.ts
@@ -114,7 +114,7 @@ export function prepRobortender(): void {
     }
     useFamiliar($familiar`Robortender`);
     const drink = toItem(drinkName);
-    if (retrievePrice(drink) > priceCap) {
+    if (!have(drink) && retrievePrice(drink) > priceCap) {
       if (mandatory) {
         setBestLeprechaunAsMeatFamiliar();
         if (


### PR DESCRIPTION
Prices for fish heads and drive-by shootings have gone up. Made a small change so that you can stock up manually and have garbo use up your inventory to feed Robortender even when prices spike.